### PR TITLE
Fix Docker permission denied for token refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ Environment variables can override sensitive values:
 - `PORT` - OAuth server port
 - `CLIENT_SECRET_ANILIST` - AniList client secret
 - `CLIENT_SECRET_MYANIMELIST` - MyAnimeList client secret
+- `TOKEN_FILE_PATH` - Token file path for persistent authentication
 
 ## Key Dependencies
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,13 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -ldflags="-w -s" 
 FROM alpine:3.19
 
 RUN apk --no-cache add ca-certificates tzdata && \
-    mkdir -p /etc/anilist-mal-sync
+    mkdir -p /etc/anilist-mal-sync && \
+    adduser -D -u 10001 appuser && \
+    mkdir -p /home/appuser/.config/anilist-mal-sync && \
+    chown -R appuser:appuser /home/appuser
 
 WORKDIR /app
 COPY --from=builder /build/main ./main
-COPY --from=builder /etc/passwd /etc/passwd
 
 USER appuser
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Override sensitive values:
 - `PORT` - OAuth server port (default: 18080)
 - `CLIENT_SECRET_ANILIST` - AniList client secret
 - `CLIENT_SECRET_MYANIMELIST` - MyAnimeList client secret
+- `TOKEN_FILE_PATH` - Token file path (default: `~/.config/anilist-mal-sync/token.json`)
 
 ## Advanced
 

--- a/config.go
+++ b/config.go
@@ -72,6 +72,10 @@ func loadConfigFromFile(filename string) (Config, error) {
 		cfg.MyAnimeList.ClientSecret = clientSecret
 	}
 
+	if tokenFilePath := os.Getenv("TOKEN_FILE_PATH"); tokenFilePath != "" {
+		cfg.TokenFilePath = tokenFilePath
+	}
+
 	if cfg.TokenFilePath == "" {
 		cfg.TokenFilePath = os.ExpandEnv("$HOME/.config/anilist-mal-sync/token.json")
 	}

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  sync:
+    image: ghcr.io/bigspawn/anilist-mal-sync:latest
+    command: ["watch"]
+    volumes:
+      - ./config.yaml:/etc/anilist-mal-sync/config.yaml:ro
+      - ./tokens:/home/appuser/.config/anilist-mal-sync
+    restart: unless-stopped


### PR DESCRIPTION
- Create home directory for appuser in Docker image
- Add TOKEN_FILE_PATH environment variable support
- Add docker-compose example configuration
- Update documentation with TOKEN_FILE_PATH usage

Fixes permission denied error when AniList token refresh tries to create temp file in mounted volume.