### PR TITLE
Add MAL_USERNAME support and validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ The application can be configured via environment variables (recommended for Doc
 - `ANILIST_USERNAME` - AniList username
 - `MAL_CLIENT_ID` - MyAnimeList client ID
 - `MAL_CLIENT_SECRET` - MyAnimeList client secret
+- `MAL_USERNAME` - MyAnimeList username
 
 **Optional environment variables:**
 - `WATCH_INTERVAL` - Sync interval for watch mode (e.g., `12h`)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ services:
       - ANILIST_USERNAME=your_anilist_username
       - MAL_CLIENT_ID=your_mal_client_id
       - MAL_CLIENT_SECRET=your_mal_secret
+      - MAL_USERNAME=your_mal_username
       # - WATCH_INTERVAL=12h  # Optional: enable watch mode
     volumes:
       - tokens:/home/appuser/.config/anilist-mal-sync
@@ -139,6 +140,7 @@ Configuration can be provided entirely via environment variables (recommended fo
 - `ANILIST_USERNAME` - AniList username
 - `MAL_CLIENT_ID` - MyAnimeList Client ID
 - `MAL_CLIENT_SECRET` - MyAnimeList Client Secret
+- `MAL_USERNAME` - MyAnimeList username
 
 **Optional:**
 - `WATCH_INTERVAL` - Sync interval for watch mode (e.g., `12h`, `24h`)
@@ -199,7 +201,7 @@ Use your system's scheduler for periodic sync:
 ## Troubleshooting
 
 **"Required environment variables not set"**
-- Set required env vars: `ANILIST_CLIENT_ID`, `ANILIST_CLIENT_SECRET`, `ANILIST_USERNAME`, `MAL_CLIENT_ID`, `MAL_CLIENT_SECRET`
+- Set required env vars: `ANILIST_CLIENT_ID`, `ANILIST_CLIENT_SECRET`, `ANILIST_USERNAME`, `MAL_CLIENT_ID`, `MAL_CLIENT_SECRET`, `MAL_USERNAME`
 - Or use config file with `-c /path/to/config.yaml`
 
 **Authentication fails**

--- a/cmd_watch_test.go
+++ b/cmd_watch_test.go
@@ -201,9 +201,11 @@ oauth:
 anilist:
   client_id: "test"
   client_secret: "test"
+  username: "ani_user"
 myanimelist:
   client_id: "test"
   client_secret: "test"
+  username: "mal_user"
 watch:
   interval: "12h"
 `
@@ -260,9 +262,11 @@ oauth:
 anilist:
   client_id: "test"
   client_secret: "test"
+  username: "ani_user"
 myanimelist:
   client_id: "test"
   client_secret: "test"
+  username: "mal_user"
 watch:
   interval: "12h"
 `
@@ -297,9 +301,11 @@ oauth:
 anilist:
   client_id: "test"
   client_secret: "test"
+  username: "ani_user"
 myanimelist:
   client_id: "test"
   client_secret: "test"
+  username: "mal_user"
 `
 	if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
 		t.Fatalf("failed to write config: %v", err)

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -14,6 +14,7 @@ services:
       - ANILIST_USERNAME=your_anilist_username
       - MAL_CLIENT_ID=your_mal_client_id
       - MAL_CLIENT_SECRET=your_mal_secret
+      - MAL_USERNAME=your_mal_username
       # Optional: Watch mode interval (e.g., 12h, 1h, 30m)
       # - WATCH_INTERVAL=12h
     volumes:

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -14,6 +14,7 @@ services:
       - ANILIST_USERNAME=your_anilist_username
       - MAL_CLIENT_ID=your_mal_client_id
       - MAL_CLIENT_SECRET=your_mal_secret
+      - MAL_USERNAME=your_mal_username
       # Optional: Watch mode interval (e.g., 12h, 1h, 30m)
       # - WATCH_INTERVAL=12h
     volumes:


### PR DESCRIPTION
## Summary

- Add `MAL_USERNAME` environment variable loading and override support
- Add validation for required fields (client_id + username for both services)
- Extract `validateConfig()` helper function to reduce cyclomatic complexity
- Add comprehensive tests for new validation logic
- Update all documentation (README.md, CLAUDE.md, docker-compose files)

## Problem Fixed

Error in Docker when `MAL_USERNAME` was not set:
```
GET .../users//animelist: 404 not_found
```

The double slash indicated an empty MAL username. This happened because:
1. `loadConfigFromEnv()` loaded `ANILIST_USERNAME` but NOT `MAL_USERNAME`
2. No validation existed to check if required fields were set before creating clients

## Changes

### Code
- `config.go`: Add `MAL_USERNAME` env var loading in `loadConfigFromEnv()`
- `config.go`: Add `MAL_USERNAME` override in `overrideConfigFromEnv()`
- `config.go`: Add `validateConfig()` helper function
- `config.go`: Add validation in `loadConfigFromFile()` at 3 locations
- `config_test.go`: Add 3 new tests for validation coverage
- `cmd_watch_test.go`: Update 4 existing tests to include username fields

### Documentation
- `README.md`: Add `MAL_USERNAME` to required env vars (3 locations)
- `docker-compose.example.yaml`: Add `MAL_USERNAME` env var
- `docker-compose.local.yaml`: Add `MAL_USERNAME` env var
- `CLAUDE.md`: Add `MAL_USERNAME` to required env vars

## Test Plan

- [x] All existing tests pass
- [x] New tests added and passing
- [x] `make check` passes (format + lint + test)
- [x] Pre-commit and pre-push hooks pass

## New Tests

1. `TestLoadConfigFromFile_EnvOverride_MAL_USERNAME` - Verifies env override works
2. `TestLoadConfigFromFile_MissingMALUsername` - Verifies validation catches missing username
3. `TestLoadConfigFromEnv_MissingRequiredFields` - Tests all combinations of missing fields