### PR TITLE
fix: cross-platform path handling for Windows compatibility

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"sync"
 	"time"
@@ -48,7 +47,7 @@ func NewOAuth(
 	authCodeOptions []oauth2.AuthCodeOption,
 	tokenFilePath string,
 ) (*OAuth, error) {
-	if !path.IsAbs(tokenFilePath) {
+	if !filepath.IsAbs(tokenFilePath) {
 		return nil, fmt.Errorf("path must be absolute: %s", tokenFilePath)
 	}
 
@@ -439,7 +438,7 @@ func createDirIfNotExists(path string) error {
 		return nil
 	}
 	if os.IsNotExist(err) {
-		if err = os.MkdirAll(dir, 0o750); err != nil {
+		if err = os.MkdirAll(dir, 0o700); err != nil {
 			return fmt.Errorf("error creating directory: %w", err)
 		}
 		return nil


### PR DESCRIPTION
## Summary

Fix critical Windows compatibility issues in path handling for OAuth token storage.

## Changes

### oauth.go
- Replace `path.IsAbs()` with `filepath.IsAbs()` to properly recognize Windows absolute paths (e.g., `C:\Users\...`)
- Strengthen directory permissions from `0o750` to `0o700` for token storage (owner only)

### config.go
- Use `os.UserConfigDir()` for default token path instead of hardcoded `$HOME/.config`
- Add `getDefaultTokenPath()` helper function for cross-platform path resolution
- Refactor `overrideConfigFromEnv()` into smaller functions to reduce cyclomatic complexity
- Refactor `loadConfigFromFile()` to reduce nesting complexity

### config_test.go
- Add `TestGetDefaultTokenPath()` to verify cross-platform default path
- Add `TestLoadConfigFromEnv_DefaultTokenPath()` for env var loading with default path
- Add `TestLoadConfigFromEnv_CustomTokenPath()` for custom path override via env var
- Update `TestLoadConfigFromFile_DefaultTokenPath()` to use `getDefaultTokenPath()`

## Backward Compatibility

✅ **macOS/Linux**: Default path remains `~/.config/anilist-mal-sync/token.json`
✅ **Windows**: Now correctly uses `%APPDATA%\anilist-mal-sync\token.json` (previously broken)
✅ Custom paths via YAML `token_file_path` or `TOKEN_FILE_PATH` env var still work

## Testing

All tests pass:
- ✅ Existing functionality preserved
- ✅ New tests added for cross-platform paths
- ✅ Linting passes (golangci-lint)