### PR TITLE
fix: add default OAuth URLs for env-based config

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,11 +60,15 @@ func loadConfigFromEnv() (Config, error) {
 			ClientID:     os.Getenv("ANILIST_CLIENT_ID"),
 			ClientSecret: os.Getenv("ANILIST_CLIENT_SECRET"),
 			Username:     os.Getenv("ANILIST_USERNAME"),
+			AuthURL:      "https://anilist.co/api/v2/oauth/authorize",
+			TokenURL:     "https://anilist.co/api/v2/oauth/token",
 		},
 		MyAnimeList: SiteConfig{
 			ClientID:     os.Getenv("MAL_CLIENT_ID"),
 			ClientSecret: os.Getenv("MAL_CLIENT_SECRET"),
 			Username:     os.Getenv("MAL_USERNAME"),
+			AuthURL:      "https://myanimelist.net/v1/oauth2/authorize",
+			TokenURL:     "https://myanimelist.net/v1/oauth2/token",
 		},
 		TokenFilePath: getEnvOrDefault("TOKEN_FILE_PATH", tokenPath),
 		Watch: WatchConfig{


### PR DESCRIPTION
Fixes #26

## Problem
When using environment variables instead of config file, OAuth authorization URL was generated without the host, showing only query parameters:
```
?client_id=xxx&code_challenge=i-xxx&...
```

## Root Cause
In `config.go`, the `loadConfigFromEnv()` function did not set default values for `AuthURL` and `TokenURL` fields in `SiteConfig`. When empty, the oauth2 library's `AuthCodeURL()` method generates a URL starting with `?`.

## Fix
Added default OAuth endpoint URLs for both AniList and MyAnimeList in `loadConfigFromEnv()`:
- AniList: `https://anilist.co/api/v2/oauth/authorize` / `.../token`
- MyAnimeList: `https://myanimelist.net/v1/oauth2/authorize` / `.../token`

## Test plan
- [x] All existing tests pass
- [x] Build succeeds