### PR TITLE
fix: add sync flags to watch command

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -18,6 +18,55 @@ const (
 	ServiceAll         = "all"
 )
 
+// syncFlags are the common flags shared between sync and watch commands
+var syncFlags = []cli.Flag{
+	&cli.BoolFlag{
+		Name:    "force",
+		Aliases: []string{"f"},
+		Usage:   "force sync all entries",
+	},
+	&cli.BoolFlag{
+		Name:    "dry-run",
+		Aliases: []string{"d"},
+		Usage:   "dry run without updating target service",
+	},
+	&cli.BoolFlag{
+		Name:  "manga",
+		Usage: "sync manga instead of anime",
+	},
+	&cli.BoolFlag{
+		Name:  "all",
+		Usage: "sync all anime and manga",
+	},
+	&cli.BoolFlag{
+		Name:  "verbose",
+		Usage: "enable verbose logging",
+	},
+	&cli.BoolFlag{
+		Name:  "reverse-direction",
+		Usage: "sync from MyAnimeList to AniList (default is AniList to MyAnimeList)",
+	},
+}
+
+// setSyncFlagsFromCmd sets global sync variables from command flags and returns verbose value
+func setSyncFlagsFromCmd(cmd *cli.Command) bool {
+	forceVal := cmd.Bool("force")
+	dryVal := cmd.Bool("dry-run")
+	mangaVal := cmd.Bool("manga")
+	allVal := cmd.Bool("all")
+	verboseVal := cmd.Bool("verbose")
+	reverseVal := cmd.Bool("reverse-direction")
+
+	forceSync = &forceVal
+	dryRun = &dryVal
+	mangaSync = &mangaVal
+	allSync = &allVal
+	verbose = &verboseVal
+	reverseDirection = &reverseVal
+
+	return verboseVal
+}
+
 // NewCLI creates the root CLI command
 func NewCLI() *cli.Command {
 	// Define flags for backward compatibility with old CLI behavior

--- a/cli_test.go
+++ b/cli_test.go
@@ -261,6 +261,40 @@ func TestCLI_StatusCommand_NoFlags(t *testing.T) {
 	}
 }
 
+func TestCLI_WatchCommand_HasSyncFlags(t *testing.T) {
+	rootCmd := NewCLI()
+
+	var watchCmd *cli.Command
+	for _, c := range rootCmd.Commands {
+		if c.Name == "watch" {
+			watchCmd = c
+			break
+		}
+	}
+
+	if watchCmd == nil {
+		t.Fatal("watch command not found")
+	}
+
+	// watch has 2 own flags (interval, once) + 6 sync flags = 8 total
+	if len(watchCmd.Flags) != 8 {
+		t.Errorf("expected 8 flags on watch command (2 watch + 6 sync), got %d", len(watchCmd.Flags))
+	}
+
+	// Check that sync flags are present
+	flagNames := make(map[string]bool)
+	for _, f := range watchCmd.Flags {
+		flagNames[f.Names()[0]] = true
+	}
+
+	syncFlagNames := []string{"force", "dry-run", "manga", "all", "verbose", "reverse-direction"}
+	for _, name := range syncFlagNames {
+		if !flagNames[name] {
+			t.Errorf("watch command missing sync flag: %s", name)
+		}
+	}
+}
+
 // =============================================================================
 // Backward Compatibility Tests
 // =============================================================================

--- a/cmd_sync.go
+++ b/cmd_sync.go
@@ -9,36 +9,9 @@ import (
 
 func newSyncCommand() *cli.Command {
 	return &cli.Command{
-		Name:  "sync",
-		Usage: "Synchronize anime/manga lists between services",
-		Flags: []cli.Flag{
-			&cli.BoolFlag{
-				Name:    "force",
-				Aliases: []string{"f"},
-				Usage:   "force sync all entries",
-			},
-			&cli.BoolFlag{
-				Name:    "dry-run",
-				Aliases: []string{"d"},
-				Usage:   "dry run without updating target service",
-			},
-			&cli.BoolFlag{
-				Name:  "manga",
-				Usage: "sync manga instead of anime",
-			},
-			&cli.BoolFlag{
-				Name:  "all",
-				Usage: "sync all anime and manga",
-			},
-			&cli.BoolFlag{
-				Name:  "verbose",
-				Usage: "enable verbose logging",
-			},
-			&cli.BoolFlag{
-				Name:  "reverse-direction",
-				Usage: "sync from MyAnimeList to AniList (default is AniList to MyAnimeList)",
-			},
-		},
+		Name:   "sync",
+		Usage:  "Synchronize anime/manga lists between services",
+		Flags:  syncFlags,
 		Action: runSync,
 	}
 }
@@ -47,19 +20,7 @@ func runSync(ctx context.Context, cmd *cli.Command) error {
 	configPath := cmd.String("config")
 
 	// Set package-level vars for compatibility with existing code
-	forceVal := cmd.Bool("force")
-	dryVal := cmd.Bool("dry-run")
-	mangaVal := cmd.Bool("manga")
-	allVal := cmd.Bool("all")
-	verboseVal := cmd.Bool("verbose")
-	reverseVal := cmd.Bool("reverse-direction")
-
-	forceSync = &forceVal
-	dryRun = &dryVal
-	mangaSync = &mangaVal
-	allSync = &allVal
-	verbose = &verboseVal
-	reverseDirection = &reverseVal
+	verboseVal := setSyncFlagsFromCmd(cmd)
 
 	// Initialize logger and add to context
 	logger := NewLogger(verboseVal)

--- a/cmd_watch_test.go
+++ b/cmd_watch_test.go
@@ -53,8 +53,9 @@ func TestWatchCommand_HasFlags(t *testing.T) {
 		t.Fatal("watch command not found")
 	}
 
-	if len(watchCmd.Flags) != 2 {
-		t.Errorf("expected 2 flags, got %d", len(watchCmd.Flags))
+	// watch has 2 own flags + 6 sync flags = 8 total
+	if len(watchCmd.Flags) != 8 {
+		t.Errorf("expected 8 flags (2 watch + 6 sync), got %d", len(watchCmd.Flags))
 	}
 
 	// Check flags by name
@@ -63,7 +64,7 @@ func TestWatchCommand_HasFlags(t *testing.T) {
 		flagNames[f.Names()[0]] = true
 	}
 
-	expectedFlags := []string{"interval", "once"}
+	expectedFlags := []string{"interval", "once", "force", "dry-run", "manga", "all", "verbose", "reverse-direction"}
 	for _, name := range expectedFlags {
 		if !flagNames[name] {
 			t.Errorf("missing flag: %s", name)


### PR DESCRIPTION
## Summary
- Watch command now supports all sync flags: `--force`, `--dry-run`, `--manga`, `--all`, `--verbose`, `--reverse-direction`
- Extracted common `syncFlags` variable to share between sync and watch commands
- Added `setSyncFlagsFromCmd()` helper to set global variables from command flags

## Test plan
- [x] `make test` passes
- [x] `make lint` passes
- [x] `go run . watch --help` shows all sync flags