### PR TITLE
refactor: defer update messages to sync summary

### DIFF
--- a/statistics.go
+++ b/statistics.go
@@ -215,6 +215,7 @@ func PrintGlobalSummary(ctx context.Context, stats []*Statistics, report *SyncRe
 		totals.items, totals.updated, totals.skipped, totals.errors)
 
 	printGlobalSkipReasons(logger, totals.skipReasons)
+	printGlobalUpdates(logger, totals.updatedItems)
 	printGlobalWarnings(logger, report)
 	printGlobalErrors(logger, totals.errorItems)
 }
@@ -223,6 +224,7 @@ type aggregatedTotals struct {
 	items, updated, skipped, errors int
 	skipReasons                     map[string]int
 	errorItems                      []UpdateResult
+	updatedItems                    []UpdateResult
 }
 
 func aggregateStats(stats []*Statistics) aggregatedTotals {
@@ -243,6 +245,7 @@ func aggregateStats(stats []*Statistics) aggregatedTotals {
 			totals.skipReasons[reason] += count
 		}
 		totals.errorItems = append(totals.errorItems, s.ErrorItems...)
+		totals.updatedItems = append(totals.updatedItems, s.UpdatedItems...)
 	}
 
 	return totals
@@ -272,6 +275,22 @@ func printGlobalWarnings(logger *Logger, report *SyncReport) {
 			logger.Warn("  %q - %s %s", w.Title, w.Reason, w.Detail)
 		} else {
 			logger.Warn("  %q - %s", w.Title, w.Reason)
+		}
+	}
+}
+
+func printGlobalUpdates(logger *Logger, updatedItems []UpdateResult) {
+	if len(updatedItems) == 0 {
+		return
+	}
+
+	logger.Info("")
+	logger.InfoSuccess("Updates (%d):", len(updatedItems))
+	for _, item := range updatedItems {
+		if item.Detail != "" {
+			logger.InfoSuccess("  %s %s", item.Title, item.Detail)
+		} else {
+			logger.InfoSuccess("  %s", item.Title)
 		}
 	}
 }

--- a/updater.go
+++ b/updater.go
@@ -174,9 +174,6 @@ func (u *Updater) updateTarget(ctx context.Context, id TargetID, src Source) {
 		Detail: detail,
 		Status: src.GetStatusString(),
 	})
-
-	// Single-line success message (replaces 3-4 lines)
-	LogInfoUpdate(ctx, src.GetTitle(), detail)
 }
 
 // generateUpdateDetail generates a concise update detail string


### PR DESCRIPTION
## Summary

- Update messages (`✓ Updated: ...`) are now accumulated and displayed at the end of sync in a dedicated "Updates (N)" section
- Previously these messages were printed immediately during processing, cluttering the progress output
- The new behavior matches how warnings are already handled (deferred to final summary)

## Test plan

- [x] Tests pass: `make test`
- [x] Code builds: `make build`
- [x] Linting passes: `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)