### PR TITLE
feat: add favorites synchronization between AniList and MAL

### DIFF
--- a/anime.go
+++ b/anime.go
@@ -77,6 +77,7 @@ type Anime struct {
 	TitleRomaji string
 	StartedAt   *time.Time
 	FinishedAt  *time.Time
+	IsFavourite bool
 }
 
 func (a Anime) GetTargetID() TargetID {
@@ -394,6 +395,11 @@ func newAnimeFromMediaListEntry(mediaList verniy.MediaList, scoreFormat verniy.S
 	startedAt := convertFuzzyDateToTimeOrNow(mediaList.StartedAt)
 	finishedAt := convertFuzzyDateToTimeOrNow(mediaList.CompletedAt)
 
+	var isFavourite bool
+	if mediaList.Media.IsFavourite != nil {
+		isFavourite = *mediaList.Media.IsFavourite
+	}
+
 	return Anime{
 		NumEpisodes: episodeNumber,
 		IDAnilist:   mediaList.Media.ID,
@@ -407,6 +413,7 @@ func newAnimeFromMediaListEntry(mediaList verniy.MediaList, scoreFormat verniy.S
 		TitleRomaji: romajiTitle,
 		StartedAt:   startedAt,
 		FinishedAt:  finishedAt,
+		IsFavourite: isFavourite,
 	}, nil
 }
 
@@ -476,6 +483,7 @@ func newAnimeFromMalAnime(malAnime mal.Anime) (Anime, error) {
 		TitleJP:     titleJP,
 		StartedAt:   startedAt,
 		FinishedAt:  finishedAt,
+		IsFavourite: false, // MAL API v2 does not provide favorites
 	}, nil
 }
 
@@ -616,8 +624,9 @@ func newAnimeFromVerniyMedia(media verniy.Media) (Anime, error) {
 		TitleEN:     titleEN,
 		TitleJP:     titleJP,
 		TitleRomaji: romajiTitle,
-		StartedAt:   nil, // Will be set from MAL source
-		FinishedAt:  nil, // Will be set from MAL source
+		StartedAt:   nil,   // Will be set from MAL source
+		FinishedAt:  nil,   // Will be set from MAL source
+		IsFavourite: false, // Verniy media from search doesn't contain user favorite status
 	}, nil
 }
 

--- a/app.go
+++ b/app.go
@@ -23,6 +23,7 @@ type App struct {
 	hatoClient         *HatoClient
 	jikanClient        *JikanClient
 	mappings           *MappingsConfig
+	favSync            *FavoritesSync
 
 	animeUpdater        *Updater
 	mangaUpdater        *Updater
@@ -30,6 +31,12 @@ type App struct {
 	reverseMangaUpdater *Updater
 
 	syncReport *SyncReport
+
+	// Cached lists for favorites sync reuse
+	fetchedAnimeFromAniList []Anime
+	fetchedAnimeFromMAL     []Anime
+	fetchedMangaFromAniList []Manga
+	fetchedMangaFromMAL     []Manga
 }
 
 // NewApp creates a new App instance with configured clients and updaters
@@ -186,6 +193,13 @@ func NewApp(ctx context.Context, config Config) (*App, error) {
 
 	// hatoClient is already created by loadIDMappingStrategies() and will be used for both strategies and cache saving
 
+	// Create favorites sync if enabled
+	var favSync *FavoritesSync
+	if config.Favorites.Enabled {
+		favSync = NewFavoritesSync(anilistClient, jikanClient, *dryRun)
+		LogInfoSuccess(ctx, "Favorites sync enabled")
+	}
+
 	return &App{
 		config:              config,
 		mal:                 malClient,
@@ -194,6 +208,7 @@ func NewApp(ctx context.Context, config Config) (*App, error) {
 		hatoClient:          hatoClient,
 		jikanClient:         jikanClient,
 		mappings:            mappings,
+		favSync:             favSync,
 		animeUpdater:        animeUpdater,
 		mangaUpdater:        mangaUpdater,
 		reverseAnimeUpdater: reverseAnimeUpdater,
@@ -277,6 +292,11 @@ func (a *App) Run(ctx context.Context) error {
 
 	// Collect unmapped entries from all updaters and save state
 	a.saveUnmappedState(ctx, updaters)
+
+	// Favorites sync phase (runs after main sync, non-fatal)
+	if a.favSync != nil {
+		a.syncFavorites(ctx)
+	}
 
 	// Print global summary
 	PrintGlobalSummary(ctx, stats, a.syncReport, time.Since(startTime))
@@ -447,6 +467,10 @@ func (a *App) fetchFromAnilistToMAL(ctx context.Context, mediaType string, prefi
 		srcs := newSourcesFromAnimes(newAnimesFromMediaListGroups(srcList, a.anilistScoreFormat))
 		tgts := newTargetsFromAnimes(newAnimesFromMalUserAnimes(tgtList))
 
+		// Cache lists for favorites sync
+		a.fetchedAnimeFromAniList = newAnimesFromMediaListGroups(srcList, a.anilistScoreFormat)
+		a.fetchedAnimeFromMAL = newAnimesFromMalUserAnimes(tgtList)
+
 		LogDebug(ctx, "[%s] Got %d from AniList, %d from MAL", prefix, len(srcs), len(tgts))
 
 		return srcs, tgts, nil
@@ -466,6 +490,10 @@ func (a *App) fetchFromAnilistToMAL(ctx context.Context, mediaType string, prefi
 
 	srcs := newSourcesFromMangas(newMangasFromMediaListGroups(srcList, a.anilistScoreFormat))
 	tgts := newTargetsFromMangas(newMangasFromMalUserMangas(tgtList))
+
+	// Cache lists for favorites sync
+	a.fetchedMangaFromAniList = newMangasFromMediaListGroups(srcList, a.anilistScoreFormat)
+	a.fetchedMangaFromMAL = newMangasFromMalUserMangas(tgtList)
 
 	LogDebug(ctx, "[%s] Got %d from AniList, %d from MAL", prefix, len(srcs), len(tgts))
 
@@ -493,6 +521,10 @@ func (a *App) fetchFromMALToAnilist(ctx context.Context, mediaType string, prefi
 		srcs := newSourcesFromAnimes(newAnimesFromMalUserAnimes(srcList))
 		tgts := newTargetsFromAnimes(newAnimesFromMediaListGroups(tgtList, a.anilistScoreFormat))
 
+		// Cache lists for favorites sync
+		a.fetchedAnimeFromMAL = newAnimesFromMalUserAnimes(srcList)
+		a.fetchedAnimeFromAniList = newAnimesFromMediaListGroups(tgtList, a.anilistScoreFormat)
+
 		LogDebug(ctx, "[%s] Got %d from MAL, %d from AniList", prefix, len(srcs), len(tgts))
 
 		return srcs, tgts, nil
@@ -513,6 +545,10 @@ func (a *App) fetchFromMALToAnilist(ctx context.Context, mediaType string, prefi
 	srcs := newSourcesFromMangas(newMangasFromMalUserMangas(srcList))
 	tgts := newTargetsFromMangas(newMangasFromMediaListGroups(tgtList, a.anilistScoreFormat))
 
+	// Cache lists for favorites sync
+	a.fetchedMangaFromMAL = newMangasFromMalUserMangas(srcList)
+	a.fetchedMangaFromAniList = newMangasFromMediaListGroups(tgtList, a.anilistScoreFormat)
+
 	LogDebug(ctx, "[%s] Got %d from MAL, %d from AniList", prefix, len(srcs), len(tgts))
 
 	return srcs, tgts, nil
@@ -526,4 +562,62 @@ func (a *App) fetchNormalSyncData(ctx context.Context, mediaType string, prefix 
 // fetchReverseSyncData fetches data for MAL -> AniList sync
 func (a *App) fetchReverseSyncData(ctx context.Context, mediaType string, prefix string) ([]Source, []Target, error) {
 	return a.fetchData(ctx, mediaType, false, prefix)
+}
+
+// syncFavorites performs favorites synchronization between AniList and MAL.
+// This is a separate phase that runs after the main status/progress sync.
+func (a *App) syncFavorites(ctx context.Context) {
+	LogStage(ctx, "Syncing favorites...")
+
+	// Fetch MAL favorites via Jikan API
+	malAnimeFavs, malMangaFavs, err := a.jikanClient.GetUserFavorites(ctx, a.config.MyAnimeList.Username)
+	if err != nil {
+		LogWarn(ctx, "Failed to fetch MAL favorites: %v (skipping favorites sync)", err)
+		return
+	}
+
+	var result FavoritesResult
+
+	if *reverseDirection {
+		// MAL -> AniList: actually sync (add missing favorites on AniList)
+		result = a.favSync.SyncToAniList(
+			ctx,
+			a.fetchedAnimeFromMAL,
+			a.fetchedMangaFromMAL,
+			malAnimeFavs,
+			malMangaFavs,
+		)
+
+		// Add result to sync report for summary display
+		a.syncReport.AddFavoritesResult(result)
+
+		if result.Added > 0 {
+			LogInfoSuccess(ctx, "Favorites sync complete: +%d added on AniList (%d skipped)",
+				result.Added, result.Skipped)
+		} else {
+			LogInfo(ctx, "Favorites sync complete: all in sync (%d entries checked)", result.Skipped)
+		}
+
+		if result.Errors > 0 {
+			LogWarn(ctx, "Favorites sync had %d errors", result.Errors)
+		}
+	} else {
+		// AniList -> MAL: only report (cannot write to MAL)
+		result = a.favSync.ReportMismatches(
+			ctx,
+			a.fetchedAnimeFromAniList,
+			a.fetchedMangaFromAniList,
+			malAnimeFavs,
+			malMangaFavs,
+		)
+
+		// Add mismatches to sync report
+		a.syncReport.AddFavoritesResult(result)
+
+		if len(result.Mismatches) > 0 {
+			LogInfo(ctx, "Favorites mismatches found: %d (AniList->MAL, report only)", len(result.Mismatches))
+		} else {
+			LogInfoSuccess(ctx, "Favorites complete: all in sync")
+		}
+	}
 }

--- a/cli.go
+++ b/cli.go
@@ -67,6 +67,10 @@ var syncFlags = []cli.Flag{
 		Name:  "jikan-api",
 		Usage: "enable Jikan API for manga ID mapping (default: false)",
 	},
+	&cli.BoolFlag{
+		Name:  "favorites",
+		Usage: "sync favorites between services (requires Jikan API for MAL favorites)",
+	},
 }
 
 // setSyncFlagsFromCmd sets global sync variables from command flags and returns verbose value
@@ -106,6 +110,13 @@ func applySyncFlagsToConfig(cmd *cli.Command, cfg *Config) {
 	}
 	if cmd.IsSet("jikan-api") {
 		cfg.JikanAPI.Enabled = cmd.Bool("jikan-api")
+	}
+	if cmd.IsSet("favorites") {
+		cfg.Favorites.Enabled = cmd.Bool("favorites")
+		// Favorites sync requires Jikan API to read MAL favorites
+		if cfg.Favorites.Enabled {
+			cfg.JikanAPI.Enabled = true
+		}
 	}
 }
 
@@ -175,6 +186,11 @@ func NewCLI() *cli.Command {
 		Usage: "enable Jikan API for manga ID mapping (default: false)",
 		Local: true,
 	}
+	favoritesFlag := &cli.BoolFlag{
+		Name:  "favorites",
+		Usage: "sync favorites between services (requires Jikan API for MAL favorites)",
+		Local: true,
+	}
 
 	return &cli.Command{
 		Name:        "anilist-mal-sync",
@@ -194,6 +210,7 @@ func NewCLI() *cli.Command {
 			armAPIFlag,
 			armAPIURLFlag,
 			jikanAPIFlag,
+			favoritesFlag,
 		},
 		Commands: []*cli.Command{
 			newLoginCommand(),

--- a/cli_test.go
+++ b/cli_test.go
@@ -35,8 +35,8 @@ func TestCLI_HasCommands(t *testing.T) {
 func TestCLI_HasFlags(t *testing.T) {
 	cmd := NewCLI()
 
-	if len(cmd.Flags) != 12 {
-		t.Errorf("expected 12 flags on root command, got %d", len(cmd.Flags))
+	if len(cmd.Flags) != 13 {
+		t.Errorf("expected 13 flags on root command, got %d", len(cmd.Flags))
 	}
 
 	// Check that important flags exist
@@ -71,8 +71,8 @@ func TestCLI_SyncCommand_HasFlags(t *testing.T) {
 		t.Fatal("sync command not found")
 	}
 
-	if len(syncCmd.Flags) != 11 {
-		t.Errorf("expected 11 flags on sync command, got %d", len(syncCmd.Flags))
+	if len(syncCmd.Flags) != 12 {
+		t.Errorf("expected 12 flags on sync command, got %d", len(syncCmd.Flags))
 	}
 
 	// Check that sync has the right flags
@@ -282,9 +282,9 @@ func TestCLI_WatchCommand_HasSyncFlags(t *testing.T) {
 		t.Fatal("watch command not found")
 	}
 
-	// watch has 2 own flags (interval, once) + 11 sync flags = 13 total
-	if len(watchCmd.Flags) != 13 {
-		t.Errorf("expected 13 flags on watch command (2 watch + 11 sync), got %d", len(watchCmd.Flags))
+	// watch has 2 own flags (interval, once) + 12 sync flags = 14 total
+	if len(watchCmd.Flags) != 14 {
+		t.Errorf("expected 14 flags on watch command (2 watch + 12 sync), got %d", len(watchCmd.Flags))
 	}
 
 	// Check that sync flags are present

--- a/cmd_watch_test.go
+++ b/cmd_watch_test.go
@@ -53,9 +53,9 @@ func TestWatchCommand_HasFlags(t *testing.T) {
 		t.Fatal("watch command not found")
 	}
 
-	// watch has 2 own flags + 11 sync flags = 13 total
-	if len(watchCmd.Flags) != 13 {
-		t.Errorf("expected 13 flags (2 watch + 11 sync), got %d", len(watchCmd.Flags))
+	// watch has 2 own flags + 12 sync flags = 14 total
+	if len(watchCmd.Flags) != 14 {
+		t.Errorf("expected 14 flags (2 watch + 12 sync), got %d", len(watchCmd.Flags))
 	}
 
 	// Check flags by name

--- a/config.go
+++ b/config.go
@@ -76,6 +76,10 @@ type JikanAPIConfig struct {
 	CacheMaxAge string `yaml:"cache_max_age"`
 }
 
+type FavoritesConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
 type Config struct {
 	OAuth            OAuthConfig           `yaml:"oauth"`
 	Anilist          SiteConfig            `yaml:"anilist"`
@@ -87,6 +91,7 @@ type Config struct {
 	ARMAPI           ARMAPIConfig          `yaml:"arm_api"`
 	HatoAPI          HatoAPIConfig         `yaml:"hato_api"`
 	JikanAPI         JikanAPIConfig        `yaml:"jikan_api"`
+	Favorites        FavoritesConfig       `yaml:"favorites"`
 	MappingsFilePath string                `yaml:"mappings_file_path"`
 }
 
@@ -141,6 +146,9 @@ func loadConfigFromEnv() (Config, error) {
 			CacheDir:    getEnvOrDefault("JIKAN_API_CACHE_DIR", getDefaultJikanCacheDir()),
 			CacheMaxAge: getEnvOrDefault("JIKAN_API_CACHE_MAX_AGE", "168h"),
 		},
+		Favorites: FavoritesConfig{
+			Enabled: getEnvBoolOrDefault("FAVORITES_SYNC_ENABLED", false),
+		},
 		MappingsFilePath: getEnvOrDefault("MAPPINGS_FILE_PATH", getDefaultMappingsPath()),
 	}
 	return cfg, nil
@@ -189,6 +197,7 @@ func overrideConfigFromEnv(cfg *Config) {
 	overrideARMAPIFromEnv(&cfg.ARMAPI)
 	overrideHatoAPIFromEnv(&cfg.HatoAPI)
 	overrideJikanAPIFromEnv(&cfg.JikanAPI)
+	overrideFavoritesFromEnv(&cfg.Favorites)
 	overrideStringFromEnv(&cfg.MappingsFilePath, "MAPPINGS_FILE_PATH")
 }
 
@@ -252,6 +261,10 @@ func overrideJikanAPIFromEnv(jc *JikanAPIConfig) {
 	overrideBoolFromEnv(&jc.Enabled, "JIKAN_API_ENABLED")
 	overrideStringFromEnv(&jc.CacheDir, "JIKAN_API_CACHE_DIR")
 	overrideStringFromEnv(&jc.CacheMaxAge, "JIKAN_API_CACHE_MAX_AGE")
+}
+
+func overrideFavoritesFromEnv(fc *FavoritesConfig) {
+	overrideBoolFromEnv(&fc.Enabled, "FAVORITES_SYNC_ENABLED")
 }
 
 // overrideStringFromEnv overrides a string field from environment variables.

--- a/config_test.go
+++ b/config_test.go
@@ -1051,3 +1051,39 @@ func TestLoadConfigFromEnv_NewSecretPrecedence(t *testing.T) {
 		t.Errorf("MyAnimeList.ClientSecret = %v, want new_mal_secret", cfg.MyAnimeList.ClientSecret)
 	}
 }
+
+func TestFavoritesSyncEnabled_FromEnv(t *testing.T) {
+	t.Setenv("ANILIST_CLIENT_ID", "test_id")
+	t.Setenv("ANILIST_USERNAME", "test_user")
+	t.Setenv("MAL_CLIENT_ID", "mal_id")
+	t.Setenv("MAL_USERNAME", "mal_user")
+
+	tests := []struct {
+		name     string
+		envValue string
+		want     bool
+	}{
+		{"Disabled", "false", false},
+		{"Enabled", "true", true},
+		{"Empty", "", false},
+		{"Zero", "0", false},
+		{"One", "1", true},
+		{"Yes", "yes", true},
+		{"No", "no", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FAVORITES_SYNC_ENABLED", tt.envValue)
+
+			cfg, err := loadConfigFromEnv()
+			if err != nil {
+				t.Fatalf("loadConfigFromEnv() failed: %v", err)
+			}
+
+			if cfg.Favorites.Enabled != tt.want {
+				t.Errorf("Favorites.Enabled = %v, want %v", cfg.Favorites.Enabled, tt.want)
+			}
+		})
+	}
+}

--- a/docs/favorites-sync.md
+++ b/docs/favorites-sync.md
@@ -1,0 +1,177 @@
+# Favorites Synchronization
+
+This document describes the favorites synchronization feature between AniList and MyAnimeList.
+
+## Overview
+
+Favorites sync is an optional feature that synchronizes your favorited anime and manga between AniList and MyAnimeList. It runs as a separate phase after the main status/progress synchronization.
+
+## API Limitations
+
+The feature has different capabilities depending on direction due to API limitations:
+
+| Direction | Read | Write | Behavior |
+|-----------|------|-------|----------|
+| MAL → AniList | ✅ via Jikan API | ✅ via ToggleFavourite mutation | Full sync (add missing favorites) |
+| AniList → MAL | ✅ via isFavourite field | ❌ MAL API v2 has no favorites endpoint | Report only |
+
+## Configuration
+
+### Enable via YAML
+
+Add to your `config.yaml`:
+
+```yaml
+favorites:
+  enabled: true
+```
+
+### Enable via Environment Variable
+
+```bash
+export FAVORITES_SYNC_ENABLED=true
+```
+
+### Enable via CLI Flag
+
+```bash
+anilist-mal-sync sync --favorites
+```
+
+The `--favorites` flag automatically enables Jikan API (required for reading MAL favorites).
+
+## Behavior by Direction
+
+### MAL → AniList (with `--reverse-direction`)
+
+- Reads your MAL favorites via Jikan API (public user profile)
+- Compares with your AniList list entries
+- **Adds** missing favorites on AniList
+- **Does not remove** favorites that exist only on AniList (you may have intentionally favorited different items)
+
+Example:
+```bash
+anilist-mal-sync sync --favorites --reverse-direction
+```
+
+Output:
+```
+[Favorites] Added "Cowboy Bebop" to AniList favorites
+[Favorites] Added "Monster" to AniList favorites
+Favorites sync complete: +2 added on AniList (15 skipped)
+```
+
+### AniList → MAL (default direction)
+
+- Reads your AniList favorites from list entries (via `isFavourite` field)
+- Reads your MAL favorites via Jikan API
+- Reports differences (cannot write to MAL)
+
+Example:
+```bash
+anilist-mal-sync sync --favorites
+```
+
+Output:
+```
+[Favorites] anime "Cowboy Bebop" is only on AniList
+[Favorites] manga "Berserk" is only on MAL
+Favorites: 2 mismatches (AniList→MAL, report only)
+```
+
+## Important Notes
+
+### MAL Profile Privacy
+
+Jikan API reads public MAL profiles. If your MAL profile is set to private, favorites sync will fail with a warning:
+
+```
+Failed to fetch MAL favorites: user username not found or profile is private (skipping favorites sync)
+```
+
+**Solution**: Set your MAL profile to public at https://myanimelist.net/editprofile.php?go=privacy
+
+### Rate Limiting
+
+AniList ToggleFavourite mutations are rate-limited (~90 requests/minute). The tool adds a 700ms delay between favorite toggles to respect this limit.
+
+### Entries Without MAL ID
+
+Anime/manga entries on your AniList list that don't have a corresponding MAL ID are skipped with a debug log:
+
+```
+[Favorites] Skipping "Some Anime" (no MAL ID)
+```
+
+### AniList Favorites Not In Your List
+
+The current implementation only compares favorites for entries that exist on **both** your AniList and MAL lists. If you've favorited an anime on AniList but haven't added it to your list, it won't be included in the sync.
+
+## Examples
+
+### Dry Run
+
+Preview what would change without actually modifying favorites:
+
+```bash
+anilist-mal-sync sync --favorites --dry-run
+```
+
+Output:
+```
+[Favorites] Would add "Cowboy Bebop" (MAL ID 1, AniList ID 1) to AniList favorites
+```
+
+### Sync Anime Only
+
+```bash
+anilist-mal-sync sync --favorites --reverse-direction
+# Only syncs anime (--manga not specified)
+```
+
+### Sync Both Anime and Manga
+
+```bash
+anilist-mal-sync sync --favorites --all --reverse-direction
+```
+
+### Verbose Output
+
+See detailed logs about skipped entries and ID matching:
+
+```bash
+anilist-mal-sync sync --favorites --verbose
+```
+
+## Configuration Options Summary
+
+| Option | CLI Flag | Env Var | YAML | Default |
+|--------|----------|---------|------|---------|
+| Enable favorites | `--favorites` | `FAVORITES_SYNC_ENABLED` | `favorites.enabled` | `false` |
+| Jikan API (auto-enabled with `--favorites`) | `--jikan-api` | `JIKAN_API_ENABLED` | `jikan_api.enabled` | `false` |
+
+## Troubleshooting
+
+### "Failed to fetch MAL favorites"
+
+**Cause**: MAL profile is private or username is incorrect.
+
+**Solution**:
+1. Verify `MAL_USERNAME` in your config
+2. Set your MAL profile to public
+
+### "No favorites added but I know I have favorites"
+
+**Possible causes**:
+1. Entries don't have MAL IDs set on AniList
+2. AniList and MAL favorites are already in sync
+3. Using wrong direction (default is AniList→MAL which is report-only)
+
+Run with `--verbose` to see detailed logs:
+```bash
+anilist-mal-sync sync --favorites --reverse-direction --verbose
+```
+
+### Jikan API Rate Limiting
+
+If you see rate limit errors from Jikan, the tool will automatically retry with exponential backoff. For large favorites lists, consider running sync less frequently.

--- a/favorites.go
+++ b/favorites.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"time"
+)
+
+// favouriteToggler abstracts the AniList ToggleFavourite mutation for testability.
+type favouriteToggler interface {
+	ToggleFavourite(ctx context.Context, animeID, mangaID int) error
+}
+
+// FavoritesSync handles synchronization of favorites between AniList and MAL.
+// Due to API limitations, only MAL -> AniList direction can write;
+// AniList -> MAL direction can only report differences.
+type FavoritesSync struct {
+	toggler favouriteToggler
+	jikan   *JikanClient
+	dryRun  bool
+}
+
+// NewFavoritesSync creates a new FavoritesSync instance.
+func NewFavoritesSync(anilist *AnilistClient, jikan *JikanClient, dryRun bool) *FavoritesSync {
+	return &FavoritesSync{
+		toggler: anilist,
+		jikan:   jikan,
+		dryRun:  dryRun,
+	}
+}
+
+// FavoritesResult contains statistics from a favorites sync operation.
+type FavoritesResult struct {
+	Added      int                // Number of favorites added
+	Skipped    int                // Number skipped (already in sync or no MAL ID)
+	Mismatches []FavoriteMismatch // Differences found (for report-only direction)
+	Errors     int                // Number of errors encountered
+}
+
+// FavoriteMismatch represents a favorite status difference between services.
+type FavoriteMismatch struct {
+	Title     string // Title of the anime/manga
+	AniListID int    // AniList ID
+	MALID     int    // MAL ID
+	MediaType string // "anime" or "manga"
+	OnAniList bool   // True if favorited on AniList
+	OnMAL     bool   // True if favorited on MAL
+}
+
+// SyncToAniList syncs favorites from MAL to AniList.
+// It adds missing favorites on AniList but does not remove favorites
+// that exist on AniList but not on MAL (user may have intentionally
+// favorited different items on each service).
+//
+// Parameters:
+//   - animes: List of anime entries with both AniList and MAL IDs
+//   - mangas: List of manga entries with both AniList and MAL IDs
+//   - malAnimeFavs: Set of MAL IDs for anime favorites on MAL
+//   - malMangaFavs: Set of MAL IDs for manga favorites on MAL
+func (f *FavoritesSync) SyncToAniList(
+	ctx context.Context,
+	animes []Anime,
+	mangas []Manga,
+	malAnimeFavs, malMangaFavs map[int]struct{},
+) FavoritesResult {
+	result := FavoritesResult{}
+
+	// Sync anime favorites
+	for _, anime := range animes {
+		if anime.IDMal <= 0 {
+			LogDebug(ctx, "[Favorites] Skipping anime %q (no MAL ID)", anime.GetTitle())
+			result.Skipped++
+			continue
+		}
+
+		malFav := isFavorite(malAnimeFavs, anime.IDMal)
+		alFav := anime.IsFavourite
+
+		// MAL favorite but not AniList favorite -> add to AniList
+		if malFav && !alFav {
+			if f.dryRun {
+				LogInfoDryRun(ctx, "[Favorites] Would add anime %q (MAL ID %d, AniList ID %d) to AniList favorites",
+					anime.GetTitle(), anime.IDMal, anime.IDAnilist)
+				result.Added++
+			} else {
+				if err := f.toggleWithRateLimit(ctx, anime.IDAnilist, 0); err != nil {
+					LogWarn(ctx, "[Favorites] Failed to add anime %q to favorites: %v", anime.GetTitle(), err)
+					result.Errors++
+				} else {
+					LogInfoUpdate(ctx, "[Favorites] Added anime %q to AniList favorites", anime.GetTitle())
+					result.Added++
+				}
+			}
+			continue
+		}
+
+		// AniList favorite but not MAL favorite -> skip (don't remove)
+		if alFav && !malFav {
+			LogDebug(ctx, "[Favorites] Anime %q is favorited on AniList but not MAL (skipping removal)", anime.GetTitle())
+			result.Skipped++
+			continue
+		}
+
+		// Both favorited or neither -> already in sync
+		result.Skipped++
+	}
+
+	// Sync manga favorites
+	for _, manga := range mangas {
+		if manga.IDMal <= 0 {
+			LogDebug(ctx, "[Favorites] Skipping manga %q (no MAL ID)", manga.GetTitle())
+			result.Skipped++
+			continue
+		}
+
+		malFav := isFavorite(malMangaFavs, manga.IDMal)
+		alFav := manga.IsFavourite
+
+		// MAL favorite but not AniList favorite -> add to AniList
+		if malFav && !alFav {
+			if f.dryRun {
+				LogInfoDryRun(ctx, "[Favorites] Would add manga %q (MAL ID %d, AniList ID %d) to AniList favorites",
+					manga.GetTitle(), manga.IDMal, manga.IDAnilist)
+				result.Added++
+			} else {
+				if err := f.toggleWithRateLimit(ctx, 0, manga.IDAnilist); err != nil {
+					LogWarn(ctx, "[Favorites] Failed to add manga %q to favorites: %v", manga.GetTitle(), err)
+					result.Errors++
+				} else {
+					LogInfoUpdate(ctx, "[Favorites] Added manga %q to AniList favorites", manga.GetTitle())
+					result.Added++
+				}
+			}
+			continue
+		}
+
+		// AniList favorite but not MAL favorite -> skip (don't remove)
+		if alFav && !malFav {
+			LogDebug(ctx, "[Favorites] Manga %q is favorited on AniList but not MAL (skipping removal)", manga.GetTitle())
+			result.Skipped++
+			continue
+		}
+
+		// Both favorited or neither -> already in sync
+		result.Skipped++
+	}
+
+	return result
+}
+
+// ReportMismatches compares favorites between AniList and MAL and reports differences.
+// This is used for the AniList -> MAL direction where we cannot write to MAL.
+//
+// Parameters:
+//   - animes: List of anime entries with both AniList and MAL IDs
+//   - mangas: List of manga entries with both AniList and MAL IDs
+//   - malAnimeFavs: Set of MAL IDs for anime favorites on MAL
+//   - malMangaFavs: Set of MAL IDs for manga favorites on MAL
+func (f *FavoritesSync) ReportMismatches(
+	ctx context.Context,
+	animes []Anime,
+	mangas []Manga,
+	malAnimeFavs, malMangaFavs map[int]struct{},
+) FavoritesResult {
+	result := FavoritesResult{
+		Mismatches: make([]FavoriteMismatch, 0),
+	}
+
+	// Compare anime favorites
+	for _, anime := range animes {
+		if anime.IDMal <= 0 {
+			continue
+		}
+
+		malFav := isFavorite(malAnimeFavs, anime.IDMal)
+		alFav := anime.IsFavourite
+
+		if malFav != alFav {
+			result.Mismatches = append(result.Mismatches, FavoriteMismatch{
+				Title:     anime.GetTitle(),
+				AniListID: anime.IDAnilist,
+				MALID:     anime.IDMal,
+				MediaType: "anime",
+				OnAniList: alFav,
+				OnMAL:     malFav,
+			})
+		}
+	}
+
+	// Compare manga favorites
+	for _, manga := range mangas {
+		if manga.IDMal <= 0 {
+			continue
+		}
+
+		malFav := isFavorite(malMangaFavs, manga.IDMal)
+		alFav := manga.IsFavourite
+
+		if malFav != alFav {
+			result.Mismatches = append(result.Mismatches, FavoriteMismatch{
+				Title:     manga.GetTitle(),
+				AniListID: manga.IDAnilist,
+				MALID:     manga.IDMal,
+				MediaType: "manga",
+				OnAniList: alFav,
+				OnMAL:     malFav,
+			})
+		}
+	}
+
+	// Log mismatches
+	for _, mm := range result.Mismatches {
+		direction := "only on"
+		if mm.OnAniList && !mm.OnMAL {
+			direction = "only on AniList"
+		} else if !mm.OnAniList && mm.OnMAL {
+			direction = "only on MAL"
+		}
+		LogInfo(ctx, "[Favorites] %s %q is %s", mm.MediaType, mm.Title, direction)
+	}
+
+	return result
+}
+
+// isFavorite checks if a MAL ID is in the favorites set.
+func isFavorite(favSet map[int]struct{}, malID int) bool {
+	_, ok := favSet[malID]
+	return ok
+}
+
+// toggleWithRateLimit calls ToggleFavourite with rate limiting to avoid hitting AniList limits.
+// AniList allows ~90 requests/minute, so we add a small delay between calls (~700ms).
+func (f *FavoritesSync) toggleWithRateLimit(ctx context.Context, animeID, mangaID int) error {
+	// Rate limit: ~90 req/min = ~700ms between requests
+	time.Sleep(700 * time.Millisecond)
+	return f.toggler.ToggleFavourite(ctx, animeID, mangaID)
+}

--- a/favorites_test.go
+++ b/favorites_test.go
@@ -1,0 +1,360 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockToggler is a test double for favouriteToggler.
+type mockToggler struct {
+	calls []mockToggleCall
+	err   error // error to return on all calls
+	// errOn maps call index to error (overrides err for specific calls)
+	errOn map[int]error
+	idx   int
+}
+
+type mockToggleCall struct {
+	AnimeID int
+	MangaID int
+}
+
+func (m *mockToggler) ToggleFavourite(_ context.Context, animeID, mangaID int) error {
+	m.calls = append(m.calls, mockToggleCall{AnimeID: animeID, MangaID: mangaID})
+	defer func() { m.idx++ }()
+	if m.errOn != nil {
+		if err, ok := m.errOn[m.idx]; ok {
+			return err
+		}
+	}
+	return m.err
+}
+
+// testCtx returns a context with a silent logger to avoid nil pointer panics in log calls.
+func testCtx() context.Context {
+	logger := NewLogger(false)
+	logger.SetOutput(io.Discard)
+	return logger.WithContext(context.Background())
+}
+
+// --- Helper builders ---
+
+func makeAnime(anilistID, malID int, title string, isFav bool) Anime {
+	return Anime{
+		IDAnilist:   anilistID,
+		IDMal:       malID,
+		TitleEN:     title,
+		IsFavourite: isFav,
+	}
+}
+
+func makeManga(anilistID, malID int, title string, isFav bool) Manga {
+	return Manga{
+		IDAnilist:   anilistID,
+		IDMal:       malID,
+		TitleEN:     title,
+		IsFavourite: isFav,
+	}
+}
+
+func favSet(ids ...int) map[int]struct{} {
+	m := make(map[int]struct{}, len(ids))
+	for _, id := range ids {
+		m[id] = struct{}{}
+	}
+	return m
+}
+
+// =============================================================================
+// isFavorite tests
+// =============================================================================
+
+func TestIsFavorite(t *testing.T) {
+	set := favSet(1, 2, 3)
+
+	assert.True(t, isFavorite(set, 1))
+	assert.True(t, isFavorite(set, 2))
+	assert.True(t, isFavorite(set, 3))
+	assert.False(t, isFavorite(set, 4))
+	assert.False(t, isFavorite(set, 0))
+}
+
+func TestIsFavorite_EmptySet(t *testing.T) {
+	assert.False(t, isFavorite(map[int]struct{}{}, 1))
+}
+
+func TestIsFavorite_NilSet(t *testing.T) {
+	assert.False(t, isFavorite(nil, 1))
+}
+
+// =============================================================================
+// Constructor tests
+// =============================================================================
+
+func TestNewFavoritesSync(t *testing.T) {
+	favSync := NewFavoritesSync(nil, nil, false)
+
+	assert.NotNil(t, favSync)
+	assert.Nil(t, favSync.toggler)
+	assert.Nil(t, favSync.jikan)
+	assert.False(t, favSync.dryRun)
+}
+
+func TestNewFavoritesSync_WithDryRun(t *testing.T) {
+	favSync := NewFavoritesSync(nil, nil, true)
+
+	assert.NotNil(t, favSync)
+	assert.True(t, favSync.dryRun)
+}
+
+// =============================================================================
+// SyncToAniList tests
+// =============================================================================
+
+func TestSyncToAniList_DryRun_CountsAdded(t *testing.T) {
+	// Anime: MAL fav, not AniList fav -> should count as Added in dry run
+	// Manga: MAL fav, not AniList fav -> should count as Added in dry run
+	fs := &FavoritesSync{toggler: &mockToggler{}, dryRun: true}
+
+	animes := []Anime{makeAnime(100, 1, "Anime A", false)}
+	mangas := []Manga{makeManga(200, 2, "Manga B", false)}
+
+	result := fs.SyncToAniList(testCtx(), animes, mangas, favSet(1), favSet(2))
+
+	assert.Equal(t, 2, result.Added)
+	assert.Equal(t, 0, result.Errors)
+	assert.Equal(t, 0, result.Skipped)
+}
+
+func TestSyncToAniList_DryRun_DoesNotCallToggle(t *testing.T) {
+	mock := &mockToggler{}
+	fs := &FavoritesSync{toggler: mock, dryRun: true}
+
+	animes := []Anime{makeAnime(100, 1, "Anime A", false)}
+	fs.SyncToAniList(testCtx(), animes, nil, favSet(1), nil)
+
+	assert.Empty(t, mock.calls, "should not call ToggleFavourite in dry run")
+}
+
+func TestSyncToAniList_AddsAnimeAndManga(t *testing.T) {
+	mock := &mockToggler{}
+	fs := &FavoritesSync{toggler: mock, dryRun: false}
+
+	animes := []Anime{makeAnime(100, 1, "Anime A", false)}
+	mangas := []Manga{makeManga(200, 2, "Manga B", false)}
+
+	result := fs.SyncToAniList(testCtx(), animes, mangas, favSet(1), favSet(2))
+
+	assert.Equal(t, 2, result.Added)
+	assert.Equal(t, 0, result.Errors)
+	assert.Len(t, mock.calls, 2)
+	// Anime toggle: animeID=100, mangaID=0
+	assert.Equal(t, mockToggleCall{AnimeID: 100, MangaID: 0}, mock.calls[0])
+	// Manga toggle: animeID=0, mangaID=200
+	assert.Equal(t, mockToggleCall{AnimeID: 0, MangaID: 200}, mock.calls[1])
+}
+
+func TestSyncToAniList_SkipsAlreadySynced(t *testing.T) {
+	mock := &mockToggler{}
+	fs := &FavoritesSync{toggler: mock, dryRun: false}
+
+	animes := []Anime{
+		makeAnime(100, 1, "Both fav", true),     // both favorited
+		makeAnime(101, 2, "Neither fav", false), // neither favorited
+	}
+
+	result := fs.SyncToAniList(testCtx(), animes, nil, favSet(1), nil)
+
+	assert.Equal(t, 0, result.Added)
+	assert.Equal(t, 2, result.Skipped)
+	assert.Empty(t, mock.calls)
+}
+
+func TestSyncToAniList_SkipsAniListOnlyFavorite(t *testing.T) {
+	// AniList favorite but not MAL -> should skip (don't remove)
+	mock := &mockToggler{}
+	fs := &FavoritesSync{toggler: mock, dryRun: false}
+
+	animes := []Anime{makeAnime(100, 1, "AL only fav", true)}
+
+	result := fs.SyncToAniList(testCtx(), animes, nil, favSet(), nil) // MAL has no favs
+
+	assert.Equal(t, 0, result.Added)
+	assert.Equal(t, 1, result.Skipped)
+	assert.Empty(t, mock.calls)
+}
+
+func TestSyncToAniList_SkipsEntriesWithoutMALID(t *testing.T) {
+	mock := &mockToggler{}
+	fs := &FavoritesSync{toggler: mock, dryRun: false}
+
+	animes := []Anime{makeAnime(100, 0, "No MAL ID", false)}
+	mangas := []Manga{makeManga(200, -1, "Negative MAL ID", false)}
+
+	result := fs.SyncToAniList(testCtx(), animes, mangas, favSet(), favSet())
+
+	assert.Equal(t, 0, result.Added)
+	assert.Equal(t, 2, result.Skipped)
+	assert.Empty(t, mock.calls)
+}
+
+func TestSyncToAniList_ErrorDoesNotCountAsAdded(t *testing.T) {
+	mock := &mockToggler{err: fmt.Errorf("API error")}
+	fs := &FavoritesSync{toggler: mock, dryRun: false}
+
+	animes := []Anime{makeAnime(100, 1, "Anime A", false)}
+
+	result := fs.SyncToAniList(testCtx(), animes, nil, favSet(1), nil)
+
+	assert.Equal(t, 0, result.Added, "failed toggle should not count as added")
+	assert.Equal(t, 1, result.Errors)
+}
+
+func TestSyncToAniList_PartialError(t *testing.T) {
+	// First call succeeds, second fails
+	mock := &mockToggler{errOn: map[int]error{1: fmt.Errorf("fail")}}
+	fs := &FavoritesSync{toggler: mock, dryRun: false}
+
+	animes := []Anime{
+		makeAnime(100, 1, "Success", false),
+		makeAnime(101, 2, "Failure", false),
+	}
+
+	result := fs.SyncToAniList(testCtx(), animes, nil, favSet(1, 2), nil)
+
+	assert.Equal(t, 1, result.Added)
+	assert.Equal(t, 1, result.Errors)
+	assert.Len(t, mock.calls, 2)
+}
+
+func TestSyncToAniList_MixedAnimeAndManga(t *testing.T) {
+	mock := &mockToggler{}
+	fs := &FavoritesSync{toggler: mock, dryRun: false}
+
+	animes := []Anime{
+		makeAnime(100, 1, "Fav anime", false),     // needs add
+		makeAnime(101, 2, "Synced anime", true),   // already synced
+		makeAnime(102, 0, "No MAL anime", false),  // skip: no MAL ID
+		makeAnime(103, 4, "AL only anime", true),  // skip: AL-only fav
+		makeAnime(104, 5, "Neither anime", false), // skip: neither
+	}
+	mangas := []Manga{
+		makeManga(200, 10, "Fav manga", false),   // needs add
+		makeManga(201, 11, "Synced manga", true), // already synced
+	}
+
+	malAnimeFavs := favSet(1, 2)   // 1=fav, 2=fav
+	malMangaFavs := favSet(10, 11) // 10=fav, 11=fav
+
+	result := fs.SyncToAniList(testCtx(), animes, mangas, malAnimeFavs, malMangaFavs)
+
+	assert.Equal(t, 2, result.Added)   // anime 100 + manga 200
+	assert.Equal(t, 5, result.Skipped) // anime 101(synced) + 102(no MAL) + 103(AL only) + 104(neither) + manga 201(synced)
+	assert.Equal(t, 0, result.Errors)
+	assert.Len(t, mock.calls, 2)
+}
+
+func TestSyncToAniList_EmptyLists(t *testing.T) {
+	mock := &mockToggler{}
+	fs := &FavoritesSync{toggler: mock, dryRun: false}
+
+	result := fs.SyncToAniList(testCtx(), nil, nil, nil, nil)
+
+	assert.Equal(t, 0, result.Added)
+	assert.Equal(t, 0, result.Skipped)
+	assert.Equal(t, 0, result.Errors)
+	assert.Empty(t, mock.calls)
+}
+
+// =============================================================================
+// ReportMismatches tests
+// =============================================================================
+
+func TestReportMismatches_FindsMismatches(t *testing.T) {
+	fs := &FavoritesSync{toggler: &mockToggler{}, dryRun: false}
+
+	animes := []Anime{
+		makeAnime(100, 1, "AL only", true),   // on AniList, not on MAL
+		makeAnime(101, 2, "MAL only", false), // on MAL, not on AniList
+		makeAnime(102, 3, "Both", true),      // both -> no mismatch
+		makeAnime(103, 4, "Neither", false),  // neither -> no mismatch
+	}
+
+	malFavs := favSet(2, 3) // 2=fav, 3=fav
+
+	result := fs.ReportMismatches(testCtx(), animes, nil, malFavs, nil)
+
+	assert.Len(t, result.Mismatches, 2)
+
+	// AL only: on AniList=true, on MAL=false
+	assert.Equal(t, "AL only", result.Mismatches[0].Title)
+	assert.True(t, result.Mismatches[0].OnAniList)
+	assert.False(t, result.Mismatches[0].OnMAL)
+	assert.Equal(t, "anime", result.Mismatches[0].MediaType)
+
+	// MAL only: on AniList=false, on MAL=true
+	assert.Equal(t, "MAL only", result.Mismatches[1].Title)
+	assert.False(t, result.Mismatches[1].OnAniList)
+	assert.True(t, result.Mismatches[1].OnMAL)
+}
+
+func TestReportMismatches_NoMismatches(t *testing.T) {
+	fs := &FavoritesSync{toggler: &mockToggler{}, dryRun: false}
+
+	animes := []Anime{
+		makeAnime(100, 1, "Both fav", true),
+		makeAnime(101, 2, "Neither", false),
+	}
+
+	result := fs.ReportMismatches(testCtx(), animes, nil, favSet(1), nil)
+
+	assert.Empty(t, result.Mismatches)
+}
+
+func TestReportMismatches_SkipsEntriesWithoutMALID(t *testing.T) {
+	fs := &FavoritesSync{toggler: &mockToggler{}, dryRun: false}
+
+	animes := []Anime{makeAnime(100, 0, "No MAL", true)}
+
+	result := fs.ReportMismatches(testCtx(), animes, nil, nil, nil)
+
+	assert.Empty(t, result.Mismatches)
+}
+
+func TestReportMismatches_MixedAnimeAndManga(t *testing.T) {
+	fs := &FavoritesSync{toggler: &mockToggler{}, dryRun: false}
+
+	animes := []Anime{makeAnime(100, 1, "Anime mismatch", true)}
+	mangas := []Manga{makeManga(200, 10, "Manga mismatch", false)}
+
+	result := fs.ReportMismatches(testCtx(), animes, mangas, favSet(), favSet(10))
+
+	assert.Len(t, result.Mismatches, 2)
+	assert.Equal(t, "anime", result.Mismatches[0].MediaType)
+	assert.Equal(t, "manga", result.Mismatches[1].MediaType)
+}
+
+func TestReportMismatches_EmptyLists(t *testing.T) {
+	fs := &FavoritesSync{toggler: &mockToggler{}, dryRun: false}
+
+	result := fs.ReportMismatches(testCtx(), nil, nil, nil, nil)
+
+	assert.Empty(t, result.Mismatches)
+}
+
+// =============================================================================
+// FavoritesResult tests
+// =============================================================================
+
+func TestFavoritesResult_DefaultValues(t *testing.T) {
+	result := FavoritesResult{}
+
+	assert.Equal(t, 0, result.Added)
+	assert.Equal(t, 0, result.Skipped)
+	assert.Equal(t, 0, result.Errors)
+	assert.Empty(t, result.Mismatches)
+}

--- a/manga.go
+++ b/manga.go
@@ -77,6 +77,7 @@ type Manga struct {
 	Volumes         int
 	StartedAt       *time.Time
 	FinishedAt      *time.Time
+	IsFavourite     bool
 }
 
 func (m Manga) GetTargetID() TargetID {
@@ -319,6 +320,11 @@ func newMangaFromMediaListEntry(mediaList verniy.MediaList, scoreFormat verniy.S
 	startedAt := convertFuzzyDateToTimeOrNow(mediaList.StartedAt)
 	finishedAt := convertFuzzyDateToTimeOrNow(mediaList.CompletedAt)
 
+	var isFavourite bool
+	if mediaList.Media.IsFavourite != nil {
+		isFavourite = *mediaList.Media.IsFavourite
+	}
+
 	return Manga{
 		IDAnilist:       mediaList.Media.ID,
 		IDMal:           idMal,
@@ -333,6 +339,7 @@ func newMangaFromMediaListEntry(mediaList verniy.MediaList, scoreFormat verniy.S
 		Volumes:         volumes,
 		StartedAt:       startedAt,
 		FinishedAt:      finishedAt,
+		IsFavourite:     isFavourite,
 	}, nil
 }
 
@@ -374,6 +381,7 @@ func newMangaFromMalManga(manga mal.Manga) (Manga, error) {
 		Volumes:         manga.NumVolumes,
 		StartedAt:       startedAt,
 		FinishedAt:      finishedAt,
+		IsFavourite:     false, // MAL API v2 does not provide favorites
 	}, nil
 }
 
@@ -536,7 +544,8 @@ func newMangaFromVerniyMedia(media verniy.Media) (Manga, error) {
 		TitleRomaji:     romajiTitle,
 		Chapters:        chapters,
 		Volumes:         volumes,
-		StartedAt:       nil, // Will be set from MAL source
-		FinishedAt:      nil, // Will be set from MAL source
+		StartedAt:       nil,   // Will be set from MAL source
+		FinishedAt:      nil,   // Will be set from MAL source
+		IsFavourite:     false, // Verniy media from search doesn't contain user favorite status
 	}, nil
 }

--- a/report.go
+++ b/report.go
@@ -4,10 +4,12 @@ import "sync"
 
 // SyncReport accumulates warnings and unmapped entries for deferred printing
 type SyncReport struct {
-	Warnings           []Warning
-	UnmappedItems      []UnmappedEntry
-	DuplicateConflicts []DuplicateConflict
-	mu                 sync.Mutex
+	Warnings            []Warning
+	UnmappedItems       []UnmappedEntry
+	DuplicateConflicts  []DuplicateConflict
+	FavoritesAdded      int
+	FavoritesMismatches []FavoriteMismatch
+	mu                  sync.Mutex
 }
 
 // DuplicateConflict records when multiple sources map to the same target.
@@ -93,4 +95,19 @@ func (r *SyncReport) HasDuplicateConflicts() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.DuplicateConflicts) > 0
+}
+
+// AddFavoritesResult adds favorites sync result to the report (thread-safe)
+func (r *SyncReport) AddFavoritesResult(result FavoritesResult) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.FavoritesAdded += result.Added
+	r.FavoritesMismatches = append(r.FavoritesMismatches, result.Mismatches...)
+}
+
+// HasFavoritesMismatches returns true if there are favorites mismatches (thread-safe)
+func (r *SyncReport) HasFavoritesMismatches() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.FavoritesMismatches) > 0
 }

--- a/statistics.go
+++ b/statistics.go
@@ -234,6 +234,7 @@ func PrintGlobalSummary(ctx context.Context, stats []*Statistics, report *SyncRe
 	printGlobalUnmapped(logger, report)
 	printGlobalWarnings(logger, report)
 	printGlobalDuplicateConflicts(logger, report)
+	printGlobalFavorites(logger, report)
 	printGlobalErrors(logger, totals.errorItems)
 }
 
@@ -404,4 +405,28 @@ func capitalizeFirst(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func printGlobalFavorites(logger *Logger, report *SyncReport) {
+	if report == nil {
+		return
+	}
+
+	// Print favorites summary if any were added or mismatches exist
+	if report.FavoritesAdded == 0 && !report.HasFavoritesMismatches() {
+		return
+	}
+
+	logger.Info("")
+	if report.FavoritesAdded > 0 {
+		logger.InfoSuccess("Favorites: +%d added on AniList", report.FavoritesAdded)
+	}
+
+	if report.HasFavoritesMismatches() {
+		direction := "AniList→MAL"
+		if *reverseDirection {
+			direction = "MAL→AniList"
+		}
+		logger.Info("Favorites: %d mismatches (%s, report only)", len(report.FavoritesMismatches), direction)
+	}
 }


### PR DESCRIPTION
## Summary

- Add optional `--favorites` flag to sync favorites from MAL to AniList (add-only, no removal) via `ToggleFavourite` GraphQL mutation
- AniList to MAL direction reports mismatches only (MAL API v2 has no favorites write endpoint)
- Fetch MAL favorites via Jikan `GetUserFavorites` endpoint; `--favorites` auto-enables Jikan API
- Add `isFavourite` field to Anime/Manga from AniList GraphQL queries
- Introduce `favouriteToggler` interface for testability with comprehensive unit tests
- Fix: `Added` counter no longer increments on toggle errors
- Fix: `ToggleFavouriteResponse` struct matches nested `nodes` GraphQL structure

## Test plan

- [x] Unit tests for SyncToAniList (dry run, success, errors, partial errors, skip logic)
- [x] Unit tests for ReportMismatches (mismatches found, no mismatches, mixed media)
- [x] Config tests for FAVORITES_SYNC_ENABLED env var
- [x] CLI flag count tests updated
- [ ] Manual test: --favorites --dry-run shows what would be synced
- [ ] Manual test: --favorites --reverse-direction adds favorites on AniList