### PR TITLE
feat: add Refresh() method to App for watch mode state reset

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApp_Refresh_ResetsPerRunState(t *testing.T) {
+	t.Parallel()
+
+	ctx := NewLogger(false).WithContext(t.Context())
+
+	app := &App{
+		config: Config{},
+		offlineStrategy: &OfflineDatabaseStrategy{
+			Database: nil,
+		},
+		animeUpdater:        newTestUpdater(),
+		mangaUpdater:        newTestUpdater(),
+		reverseAnimeUpdater: newTestUpdater(),
+		reverseMangaUpdater: newTestUpdater(),
+		syncReport:          NewSyncReport(),
+	}
+
+	// Simulate accumulated state from a previous run
+	app.animeUpdater.Statistics.UpdatedCount = 5
+	app.animeUpdater.UnmappedList = []UnmappedEntry{{Title: "test"}}
+	app.mangaUpdater.Statistics.SkippedCount = 3
+	app.reverseAnimeUpdater.Statistics.ErrorCount = 2
+	app.reverseMangaUpdater.UnmappedList = []UnmappedEntry{{Title: "test2"}}
+	app.syncReport.AddWarning("test", "warning", "detail", "anime")
+
+	app.Refresh(ctx)
+
+	// Statistics should be reset
+	assert.Equal(t, 0, app.animeUpdater.Statistics.UpdatedCount)
+	assert.Equal(t, 0, app.mangaUpdater.Statistics.SkippedCount)
+	assert.Equal(t, 0, app.reverseAnimeUpdater.Statistics.ErrorCount)
+	assert.Equal(t, 0, app.reverseMangaUpdater.Statistics.UpdatedCount)
+
+	// UnmappedList should be nil
+	assert.Nil(t, app.animeUpdater.UnmappedList)
+	assert.Nil(t, app.reverseMangaUpdater.UnmappedList)
+
+	// SyncReport should be fresh (no warnings)
+	assert.Empty(t, app.syncReport.Warnings)
+}
+
+func newTestUpdater() *Updater {
+	return &Updater{
+		Statistics:    NewStatistics(),
+		StrategyChain: NewStrategyChain(),
+	}
+}

--- a/cmd_watch.go
+++ b/cmd_watch.go
@@ -101,6 +101,7 @@ func runWatch(ctx context.Context, cmd *cli.Command) error {
 		select {
 		case <-ticker.C:
 			log.Printf("Running scheduled sync...")
+			app.Refresh(ctx)
 			if err := app.Run(ctx); err != nil {
 				log.Printf("Sync error: %v", err)
 			} else {


### PR DESCRIPTION
## Summary

- Add `Refresh()` method to `App` that resets per-run state (statistics, unmapped lists, sync report) and optionally reloads the offline database when `auto_update` is enabled
- Store `*OfflineDatabaseStrategy` pointer in `App` to allow database hot-reload without recreating strategy chains
- Call `Refresh()` before each scheduled `Run()` in watch mode ticker loop

Fixes state accumulation bugs in watch mode where statistics, unmapped entries, and sync report warnings grew indefinitely across sync cycles.

## Test plan

- [x] New `TestApp_Refresh_ResetsPerRunState` verifies all state is properly reset
- [x] All existing tests pass
- [x] Lint clean