### PR TITLE
feat: respect Retry-After header from AniList rate limit responses

### DIFF
--- a/http_retry.go
+++ b/http_retry.go
@@ -58,6 +58,9 @@ func isRetryable(err error, resp *http.Response) bool {
 			strings.Contains(errStr, "connection reset") ||
 			strings.Contains(errStr, "broken pipe")
 	}
+	if resp == nil {
+		return false
+	}
 	return shouldRetryStatus(resp.StatusCode)
 }
 
@@ -140,7 +143,10 @@ func executeWithRetry(
 
 		// Compute the wait for the next retry before closing the response
 		// so we can read the Retry-After header if present.
-		nextWait, rateLimited = retryAfterOrBackoff(resp, attempt+1, backoff)
+		// Skip on the last iteration — the value will never be used.
+		if attempt < maxRetries {
+			nextWait, rateLimited = retryAfterOrBackoff(resp, attempt+1, backoff)
+		}
 
 		if resp != nil {
 			_ = resp.Body.Close()
@@ -164,6 +170,21 @@ func executeWithRetry(
 	return nil, fmt.Errorf("max retries (%d) exhausted", maxRetries)
 }
 
+// parseRetryAfter parses the value of a Retry-After header per RFC 7231 §7.1.3.
+// Supports both delay-seconds (integer) and HTTP-date formats.
+// Returns the duration to wait and true if the value is valid and in the future.
+func parseRetryAfter(v string) (time.Duration, bool) {
+	if seconds, err := strconv.Atoi(v); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second, true
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d, true
+		}
+	}
+	return 0, false
+}
+
 // retryAfterOrBackoff returns the wait duration before the next retry and
 // whether the duration came from a Retry-After header (true) or backoff (false).
 // For 429 Too Many Requests responses with a Retry-After header, it uses
@@ -172,8 +193,8 @@ func executeWithRetry(
 func retryAfterOrBackoff(resp *http.Response, attempt int, backoff BackoffStrategy) (time.Duration, bool) {
 	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
 		if v := resp.Header.Get("Retry-After"); v != "" {
-			if seconds, err := strconv.Atoi(v); err == nil && seconds > 0 {
-				return time.Duration(seconds) * time.Second, true
+			if d, ok := parseRetryAfter(v); ok {
+				return d, true
 			}
 		}
 	}

--- a/http_retry.go
+++ b/http_retry.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -108,15 +109,15 @@ func executeWithRetry(
 	doRequest func(*http.Request) (*http.Response, error),
 ) (*http.Response, error) {
 	var lastErr error
+	var nextWait time.Duration
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
-			wait := backoff.Duration(attempt)
 			LogWarn(req.Context(), "[HTTP RETRY] Attempt %d/%d for %s (waiting %v)",
-				attempt, maxRetries, req.URL, wait)
+				attempt, maxRetries, req.URL, nextWait)
 
 			select {
-			case <-time.After(wait):
+			case <-time.After(nextWait):
 			case <-req.Context().Done():
 				return nil, req.Context().Err()
 			}
@@ -128,6 +129,10 @@ func executeWithRetry(
 		if err == nil && !shouldRetryStatus(resp.StatusCode) {
 			return resp, nil
 		}
+
+		// Compute the wait for the next retry before closing the response
+		// so we can read the Retry-After header if present.
+		nextWait = retryAfterOrBackoff(resp, attempt+1, backoff)
 
 		if resp != nil {
 			_ = resp.Body.Close()
@@ -149,6 +154,21 @@ func executeWithRetry(
 		return nil, lastErr
 	}
 	return nil, fmt.Errorf("max retries (%d) exhausted", maxRetries)
+}
+
+// retryAfterOrBackoff returns the wait duration before the next retry.
+// For 429 Too Many Requests responses with a Retry-After header, it uses
+// that value to wait precisely until the rate limit window resets.
+// Falls back to exponential backoff otherwise.
+func retryAfterOrBackoff(resp *http.Response, attempt int, backoff BackoffStrategy) time.Duration {
+	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+		if v := resp.Header.Get("Retry-After"); v != "" {
+			if seconds, err := strconv.Atoi(v); err == nil && seconds > 0 {
+				return time.Duration(seconds) * time.Second
+			}
+		}
+	}
+	return backoff.Duration(attempt)
 }
 
 // withTimeout adds a timeout to the context for API calls.

--- a/http_retry.go
+++ b/http_retry.go
@@ -174,10 +174,12 @@ func executeWithRetry(
 // Supports both delay-seconds (integer) and HTTP-date formats.
 // Returns the duration to wait and true if the value is valid and in the future.
 func parseRetryAfter(v string) (time.Duration, bool) {
-	if seconds, err := strconv.Atoi(v); err == nil && seconds > 0 {
+	seconds, err := strconv.Atoi(v)
+	if err == nil && seconds > 0 {
 		return time.Duration(seconds) * time.Second, true
 	}
-	if t, err := http.ParseTime(v); err == nil {
+	t, err := http.ParseTime(v)
+	if err == nil {
 		if d := time.Until(t); d > 0 {
 			return d, true
 		}

--- a/http_retry.go
+++ b/http_retry.go
@@ -110,11 +110,17 @@ func executeWithRetry(
 ) (*http.Response, error) {
 	var lastErr error
 	var nextWait time.Duration
+	var rateLimited bool
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
-			LogWarn(req.Context(), "[HTTP RETRY] Attempt %d/%d for %s (waiting %v)",
-				attempt, maxRetries, req.URL, nextWait)
+			if rateLimited {
+				LogWarn(req.Context(), "[HTTP RETRY] Attempt %d/%d for %s (rate limited, waiting %v)",
+					attempt, maxRetries, req.URL, nextWait)
+			} else {
+				LogWarn(req.Context(), "[HTTP RETRY] Attempt %d/%d for %s (waiting %v)",
+					attempt, maxRetries, req.URL, nextWait)
+			}
 
 			select {
 			case <-time.After(nextWait):
@@ -132,7 +138,7 @@ func executeWithRetry(
 
 		// Compute the wait for the next retry before closing the response
 		// so we can read the Retry-After header if present.
-		nextWait = retryAfterOrBackoff(resp, attempt+1, backoff)
+		nextWait, rateLimited = retryAfterOrBackoff(resp, attempt+1, backoff)
 
 		if resp != nil {
 			_ = resp.Body.Close()
@@ -156,19 +162,20 @@ func executeWithRetry(
 	return nil, fmt.Errorf("max retries (%d) exhausted", maxRetries)
 }
 
-// retryAfterOrBackoff returns the wait duration before the next retry.
+// retryAfterOrBackoff returns the wait duration before the next retry and
+// whether the duration came from a Retry-After header (true) or backoff (false).
 // For 429 Too Many Requests responses with a Retry-After header, it uses
 // that value to wait precisely until the rate limit window resets.
 // Falls back to exponential backoff otherwise.
-func retryAfterOrBackoff(resp *http.Response, attempt int, backoff BackoffStrategy) time.Duration {
+func retryAfterOrBackoff(resp *http.Response, attempt int, backoff BackoffStrategy) (time.Duration, bool) {
 	if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
 		if v := resp.Header.Get("Retry-After"); v != "" {
 			if seconds, err := strconv.Atoi(v); err == nil && seconds > 0 {
-				return time.Duration(seconds) * time.Second
+				return time.Duration(seconds) * time.Second, true
 			}
 		}
 	}
-	return backoff.Duration(attempt)
+	return backoff.Duration(attempt), false
 }
 
 // withTimeout adds a timeout to the context for API calls.

--- a/http_retry.go
+++ b/http_retry.go
@@ -122,9 +122,11 @@ func executeWithRetry(
 					attempt, maxRetries, req.URL, nextWait)
 			}
 
+			timer := time.NewTimer(nextWait)
 			select {
-			case <-time.After(nextWait):
+			case <-timer.C:
 			case <-req.Context().Done():
+				timer.Stop()
 				return nil, req.Context().Err()
 			}
 		}

--- a/http_retry_test.go
+++ b/http_retry_test.go
@@ -298,6 +298,135 @@ func TestRetryableRoundTripper_MaxRetriesExhausted(t *testing.T) {
 	}
 }
 
+func TestRetryAfterOrBackoff(t *testing.T) {
+	backoff := &ExponentialBackoff{
+		InitialInterval: 1 * time.Second,
+		MaxInterval:     30 * time.Second,
+		Multiplier:      2.0,
+	}
+
+	tests := []struct {
+		name     string
+		resp     *http.Response
+		attempt  int
+		expected time.Duration
+	}{
+		{
+			name: "uses Retry-After header on 429",
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"30"}},
+			},
+			attempt:  1,
+			expected: 30 * time.Second,
+		},
+		{
+			name: "falls back to backoff when no Retry-After header",
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{},
+			},
+			attempt:  1,
+			expected: 1 * time.Second,
+		},
+		{
+			name: "ignores Retry-After for non-429 status",
+			resp: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Header:     http.Header{"Retry-After": []string{"30"}},
+			},
+			attempt:  1,
+			expected: 1 * time.Second,
+		},
+		{
+			name: "falls back to backoff when Retry-After is not a number",
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"not-a-number"}},
+			},
+			attempt:  1,
+			expected: 1 * time.Second,
+		},
+		{
+			name:     "falls back to backoff when resp is nil",
+			resp:     nil,
+			attempt:  1,
+			expected: 1 * time.Second,
+		},
+		{
+			name: "falls back to backoff when Retry-After is zero",
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"0"}},
+			},
+			attempt:  1,
+			expected: 1 * time.Second,
+		},
+		{
+			name: "uses Retry-After regardless of backoff attempt number",
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"60"}},
+			},
+			attempt:  3,
+			expected: 60 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := retryAfterOrBackoff(tt.resp, tt.attempt, backoff)
+			if got != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestRetryableRoundTripper_RetryAfterHeaderIsUsed(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Use a backoff much longer than Retry-After to confirm Retry-After wins.
+	transport := &retryableRoundTripper{
+		underlying: http.DefaultTransport,
+		maxRetries: 3,
+		backoff: &ExponentialBackoff{
+			InitialInterval: 30 * time.Second,
+			MaxInterval:     60 * time.Second,
+			Multiplier:      2.0,
+		},
+	}
+	client := &http.Client{Transport: transport}
+
+	start := time.Now()
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+	// Should have waited ~1s (Retry-After), not 30s (backoff).
+	if elapsed >= 10*time.Second {
+		t.Fatalf("waited too long (%v): Retry-After header was not used", elapsed)
+	}
+}
+
 func TestNewRetryableTransport_DefaultTransport(t *testing.T) {
 	client := &http.Client{} // Transport is nil
 	transport := NewRetryableTransport(client, 3)

--- a/http_retry_test.go
+++ b/http_retry_test.go
@@ -299,6 +299,7 @@ func TestRetryableRoundTripper_MaxRetriesExhausted(t *testing.T) {
 }
 
 func TestRetryAfterOrBackoff(t *testing.T) {
+	t.Parallel()
 	backoff := &ExponentialBackoff{
 		InitialInterval: 1 * time.Second,
 		MaxInterval:     30 * time.Second,
@@ -405,6 +406,7 @@ func TestRetryAfterOrBackoff(t *testing.T) {
 }
 
 func TestIsRetryable(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		err      error
@@ -484,6 +486,7 @@ func TestIsRetryable(t *testing.T) {
 }
 
 func TestCloneRequest_NilBody(t *testing.T) {
+	t.Parallel()
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
 	cloned := cloneRequest(req)
 

--- a/http_retry_test.go
+++ b/http_retry_test.go
@@ -473,6 +473,12 @@ func TestIsRetryable(t *testing.T) {
 			resp:     &http.Response{StatusCode: http.StatusBadRequest},
 			expected: false,
 		},
+		{
+			name:     "nil error and nil response returns false without panic",
+			err:      nil,
+			resp:     nil,
+			expected: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -598,5 +604,140 @@ func TestNewRetryableTransport_DefaultTransport(t *testing.T) {
 
 	if rt.underlying == nil {
 		t.Fatal("expected underlying transport to be set to http.DefaultTransport")
+	}
+}
+
+// =============================================================================
+// parseRetryAfter
+// =============================================================================
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		value     string
+		wantOk    bool
+		wantExact time.Duration // only checked when wantOk && >= 0
+		wantMin   time.Duration // for approximate checks (HTTP-date)
+		wantMax   time.Duration
+	}{
+		{
+			name:      "integer seconds",
+			value:     "30",
+			wantOk:    true,
+			wantExact: 30 * time.Second,
+		},
+		{
+			name:   "zero seconds",
+			value:  "0",
+			wantOk: false,
+		},
+		{
+			name:   "negative seconds",
+			value:  "-10",
+			wantOk: false,
+		},
+		{
+			name:   "invalid string",
+			value:  "not-a-number",
+			wantOk: false,
+		},
+		{
+			name:   "empty string",
+			value:  "",
+			wantOk: false,
+		},
+		{
+			name:   "past HTTP-date",
+			value:  "Mon, 02 Jan 2006 15:04:05 GMT",
+			wantOk: false,
+		},
+		{
+			name:    "future HTTP-date",
+			value:   time.Now().Add(60 * time.Second).UTC().Format(http.TimeFormat),
+			wantOk:  true,
+			wantMin: 50 * time.Second,
+			wantMax: 65 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, ok := parseRetryAfter(tt.value)
+			if ok != tt.wantOk {
+				t.Fatalf("ok: expected %v, got %v (duration=%v)", tt.wantOk, ok, d)
+			}
+			if !tt.wantOk {
+				return
+			}
+			if tt.wantExact > 0 {
+				if d != tt.wantExact {
+					t.Fatalf("duration: expected %v, got %v", tt.wantExact, d)
+				}
+			} else {
+				if d < tt.wantMin || d > tt.wantMax {
+					t.Fatalf("duration %v not in expected range [%v, %v]", d, tt.wantMin, tt.wantMax)
+				}
+			}
+		})
+	}
+}
+
+func TestRetryAfterOrBackoff_HTTPDate(t *testing.T) {
+	t.Parallel()
+	backoff := &ExponentialBackoff{
+		InitialInterval: 1 * time.Second,
+		MaxInterval:     30 * time.Second,
+		Multiplier:      2.0,
+	}
+
+	futureDate := time.Now().Add(60 * time.Second).UTC().Format(http.TimeFormat)
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{futureDate}},
+	}
+
+	got, fromHeader := retryAfterOrBackoff(resp, 1, backoff)
+	if !fromHeader {
+		t.Fatal("expected fromHeader=true for HTTP-date Retry-After")
+	}
+	// HTTP-date is truncated to seconds, so allow ±5s tolerance.
+	if got < 55*time.Second || got > 65*time.Second {
+		t.Fatalf("expected duration ~60s, got %v", got)
+	}
+}
+
+// =============================================================================
+// executeWithRetry — backoff skipped on last attempt
+// =============================================================================
+
+// countingBackoff records how many times Duration is called.
+type countingBackoff struct {
+	calls int
+}
+
+func (c *countingBackoff) Duration(_ int) time.Duration {
+	c.calls++
+	return 0 // zero so tests run instantly
+}
+
+func TestExecuteWithRetry_SkipsBackoffOnLastAttempt(t *testing.T) {
+	t.Parallel()
+	const maxRetries = 3
+
+	cb := &countingBackoff{}
+
+	// All requests fail with a retryable error.
+	doRequest := func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("connection refused")
+	}
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost:1", nil)
+	_, _ = executeWithRetry(req, maxRetries, cb, doRequest)
+
+	// Attempts: 0, 1, 2, 3 — backoff computed before attempts 1,2,3 only.
+	// The last attempt (3 == maxRetries) must NOT trigger a backoff call.
+	if cb.calls != maxRetries {
+		t.Fatalf("expected %d backoff calls, got %d", maxRetries, cb.calls)
 	}
 }

--- a/http_retry_test.go
+++ b/http_retry_test.go
@@ -733,7 +733,10 @@ func TestExecuteWithRetry_SkipsBackoffOnLastAttempt(t *testing.T) {
 	}
 
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost:1", nil)
-	_, _ = executeWithRetry(req, maxRetries, cb, doRequest)
+	resp, _ := executeWithRetry(req, maxRetries, cb, doRequest)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
 
 	// Attempts: 0, 1, 2, 3 — backoff computed before attempts 1,2,3 only.
 	// The last attempt (3 == maxRetries) must NOT trigger a backoff call.

--- a/http_retry_test.go
+++ b/http_retry_test.go
@@ -306,10 +306,11 @@ func TestRetryAfterOrBackoff(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		resp     *http.Response
-		attempt  int
-		expected time.Duration
+		name        string
+		resp        *http.Response
+		attempt     int
+		expected    time.Duration
+		fromHeader  bool
 	}{
 		{
 			name: "uses Retry-After header on 429",
@@ -317,8 +318,9 @@ func TestRetryAfterOrBackoff(t *testing.T) {
 				StatusCode: http.StatusTooManyRequests,
 				Header:     http.Header{"Retry-After": []string{"30"}},
 			},
-			attempt:  1,
-			expected: 30 * time.Second,
+			attempt:    1,
+			expected:   30 * time.Second,
+			fromHeader: true,
 		},
 		{
 			name: "falls back to backoff when no Retry-After header",
@@ -326,8 +328,9 @@ func TestRetryAfterOrBackoff(t *testing.T) {
 				StatusCode: http.StatusTooManyRequests,
 				Header:     http.Header{},
 			},
-			attempt:  1,
-			expected: 1 * time.Second,
+			attempt:    1,
+			expected:   1 * time.Second,
+			fromHeader: false,
 		},
 		{
 			name: "ignores Retry-After for non-429 status",
@@ -335,8 +338,9 @@ func TestRetryAfterOrBackoff(t *testing.T) {
 				StatusCode: http.StatusInternalServerError,
 				Header:     http.Header{"Retry-After": []string{"30"}},
 			},
-			attempt:  1,
-			expected: 1 * time.Second,
+			attempt:    1,
+			expected:   1 * time.Second,
+			fromHeader: false,
 		},
 		{
 			name: "falls back to backoff when Retry-After is not a number",
@@ -344,14 +348,16 @@ func TestRetryAfterOrBackoff(t *testing.T) {
 				StatusCode: http.StatusTooManyRequests,
 				Header:     http.Header{"Retry-After": []string{"not-a-number"}},
 			},
-			attempt:  1,
-			expected: 1 * time.Second,
+			attempt:    1,
+			expected:   1 * time.Second,
+			fromHeader: false,
 		},
 		{
-			name:     "falls back to backoff when resp is nil",
-			resp:     nil,
-			attempt:  1,
-			expected: 1 * time.Second,
+			name:       "falls back to backoff when resp is nil",
+			resp:       nil,
+			attempt:    1,
+			expected:   1 * time.Second,
+			fromHeader: false,
 		},
 		{
 			name: "falls back to backoff when Retry-After is zero",
@@ -359,8 +365,9 @@ func TestRetryAfterOrBackoff(t *testing.T) {
 				StatusCode: http.StatusTooManyRequests,
 				Header:     http.Header{"Retry-After": []string{"0"}},
 			},
-			attempt:  1,
-			expected: 1 * time.Second,
+			attempt:    1,
+			expected:   1 * time.Second,
+			fromHeader: false,
 		},
 		{
 			name: "uses Retry-After regardless of backoff attempt number",
@@ -368,18 +375,164 @@ func TestRetryAfterOrBackoff(t *testing.T) {
 				StatusCode: http.StatusTooManyRequests,
 				Header:     http.Header{"Retry-After": []string{"60"}},
 			},
-			attempt:  3,
-			expected: 60 * time.Second,
+			attempt:    3,
+			expected:   60 * time.Second,
+			fromHeader: true,
+		},
+		{
+			name: "falls back to backoff when Retry-After is negative",
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     http.Header{"Retry-After": []string{"-10"}},
+			},
+			attempt:    1,
+			expected:   1 * time.Second,
+			fromHeader: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := retryAfterOrBackoff(tt.resp, tt.attempt, backoff)
+			got, fromHeader := retryAfterOrBackoff(tt.resp, tt.attempt, backoff)
+			if got != tt.expected {
+				t.Fatalf("duration: expected %v, got %v", tt.expected, got)
+			}
+			if fromHeader != tt.fromHeader {
+				t.Fatalf("fromHeader: expected %v, got %v", tt.fromHeader, fromHeader)
+			}
+		})
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		resp     *http.Response
+		expected bool
+	}{
+		{
+			name:     "connection refused error",
+			err:      errors.New("dial tcp: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "connection reset error",
+			err:      errors.New("read: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "broken pipe error",
+			err:      errors.New("write: broken pipe"),
+			expected: true,
+		},
+		{
+			name:     "other error not retryable",
+			err:      errors.New("EOF"),
+			expected: false,
+		},
+		{
+			name:     "timeout error not retryable",
+			err:      errors.New("context deadline exceeded"),
+			expected: false,
+		},
+		{
+			name:     "429 response is retryable",
+			resp:     &http.Response{StatusCode: http.StatusTooManyRequests},
+			expected: true,
+		},
+		{
+			name:     "500 response is retryable",
+			resp:     &http.Response{StatusCode: http.StatusInternalServerError},
+			expected: true,
+		},
+		{
+			name:     "502 response is retryable",
+			resp:     &http.Response{StatusCode: http.StatusBadGateway},
+			expected: true,
+		},
+		{
+			name:     "503 response is retryable",
+			resp:     &http.Response{StatusCode: http.StatusServiceUnavailable},
+			expected: true,
+		},
+		{
+			name:     "200 response is not retryable",
+			resp:     &http.Response{StatusCode: http.StatusOK},
+			expected: false,
+		},
+		{
+			name:     "404 response is not retryable",
+			resp:     &http.Response{StatusCode: http.StatusNotFound},
+			expected: false,
+		},
+		{
+			name:     "400 response is not retryable",
+			resp:     &http.Response{StatusCode: http.StatusBadRequest},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetryable(tt.err, tt.resp)
 			if got != tt.expected {
 				t.Fatalf("expected %v, got %v", tt.expected, got)
 			}
 		})
+	}
+}
+
+func TestCloneRequest_NilBody(t *testing.T) {
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.com", nil)
+	cloned := cloneRequest(req)
+
+	if cloned.URL.String() != req.URL.String() {
+		t.Fatalf("URL not cloned: got %s", cloned.URL)
+	}
+	if cloned.Body != nil && cloned.Body != http.NoBody {
+		t.Fatal("expected nil/NoBody for nil original body")
+	}
+}
+
+func TestRetryableRoundTripper_RateLimitedLogMessage(t *testing.T) {
+	// Verify that a 429 with Retry-After triggers the "rate limited" log path.
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
+		if attempts == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var buf strings.Builder
+	logger := NewLogger(false)
+	logger.SetOutput(&buf)
+	ctx := logger.WithContext(t.Context())
+
+	transport := &retryableRoundTripper{
+		underlying: http.DefaultTransport,
+		maxRetries: 3,
+		backoff:    &defaultBackoffConfig,
+	}
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+	if !strings.Contains(buf.String(), "rate limited") {
+		t.Fatalf("expected 'rate limited' in log output, got: %s", buf.String())
 	}
 }
 

--- a/http_retry_test.go
+++ b/http_retry_test.go
@@ -531,7 +531,7 @@ func TestRetryableRoundTripper_RateLimitedLogMessage(t *testing.T) {
 	client := &http.Client{Transport: transport}
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -572,7 +572,7 @@ func TestRetryableRoundTripper_RetryAfterHeaderIsUsed(t *testing.T) {
 
 	start := time.Now()
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
 	elapsed := time.Since(start)
 
 	if err != nil {

--- a/http_retry_test.go
+++ b/http_retry_test.go
@@ -307,11 +307,11 @@ func TestRetryAfterOrBackoff(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		resp        *http.Response
-		attempt     int
-		expected    time.Duration
-		fromHeader  bool
+		name       string
+		resp       *http.Response
+		attempt    int
+		expected   time.Duration
+		fromHeader bool
 	}{
 		{
 			name: "uses Retry-After header on 429",

--- a/logging_test.go
+++ b/logging_test.go
@@ -121,4 +121,3 @@ type errorTransport struct {
 func (e *errorTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
 	return nil, e.err
 }
-

--- a/logging_test.go
+++ b/logging_test.go
@@ -30,8 +30,8 @@ func TestLoggingRoundTripper_NonVerbose_DoesNotLog(t *testing.T) {
 	assert.NoError(t, err)
 	_ = resp.Body.Close()
 
-	// Non-verbose mode: no debug HTTP logs
-	assert.NotContains(t, buf.String(), "GET")
+	// Non-verbose mode produces no log output at all.
+	assert.Empty(t, buf.String(), "non-verbose mode should produce no log output")
 }
 
 func TestLoggingRoundTripper_Verbose_LogsRequest(t *testing.T) {

--- a/logging_test.go
+++ b/logging_test.go
@@ -26,7 +26,7 @@ func TestLoggingRoundTripper_NonVerbose_DoesNotLog(t *testing.T) {
 
 	ctx := logger.WithContext(t.Context())
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
 	assert.NoError(t, err)
 	_ = resp.Body.Close()
 
@@ -51,7 +51,7 @@ func TestLoggingRoundTripper_Verbose_LogsRequest(t *testing.T) {
 
 	ctx := logger.WithContext(t.Context())
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
 	assert.NoError(t, err)
 	_ = resp.Body.Close()
 
@@ -74,7 +74,10 @@ func TestLoggingRoundTripper_Verbose_LogsError(t *testing.T) {
 
 	ctx := logger.WithContext(t.Context())
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:1", nil)
-	_, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
 	assert.Error(t, err)
 
 	output := buf.String()
@@ -92,7 +95,7 @@ func TestLoggingRoundTripper_NonVerbose_PassesThrough(t *testing.T) {
 	client := &http.Client{Transport: rt}
 
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
 	assert.NoError(t, err)
 	_ = resp.Body.Close()
 
@@ -109,7 +112,10 @@ func TestLoggingRoundTripper_NonVerbose_PropagatesError(t *testing.T) {
 	client := &http.Client{Transport: rt}
 
 	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost:1", nil)
-	_, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
 	assert.ErrorIs(t, err, wantErr)
 }
 

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggingRoundTripper_NonVerbose_DoesNotLog(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var buf strings.Builder
+	logger := NewLogger(true) // verbose logger
+	logger.SetOutput(&buf)
+
+	rt := &loggingRoundTripper{base: http.DefaultTransport, verbose: false}
+	client := &http.Client{Transport: rt}
+
+	ctx := logger.WithContext(t.Context())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	_ = resp.Body.Close()
+
+	// Non-verbose mode: no debug HTTP logs
+	assert.NotContains(t, buf.String(), "GET")
+}
+
+func TestLoggingRoundTripper_Verbose_LogsRequest(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var buf strings.Builder
+	logger := NewLogger(true)
+	logger.SetOutput(&buf)
+	logger.level = LogLevelDebug
+
+	rt := &loggingRoundTripper{base: http.DefaultTransport, verbose: true}
+	client := &http.Client{Transport: rt}
+
+	ctx := logger.WithContext(t.Context())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	_ = resp.Body.Close()
+
+	output := buf.String()
+	assert.Contains(t, output, "GET")
+	assert.Contains(t, output, "200")
+}
+
+func TestLoggingRoundTripper_Verbose_LogsError(t *testing.T) {
+	t.Parallel()
+	errTransport := &errorTransport{err: errors.New("connection refused")}
+
+	var buf strings.Builder
+	logger := NewLogger(true)
+	logger.SetOutput(&buf)
+	logger.level = LogLevelDebug
+
+	rt := &loggingRoundTripper{base: errTransport, verbose: true}
+	client := &http.Client{Transport: rt}
+
+	ctx := logger.WithContext(t.Context())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:1", nil)
+	_, err := client.Do(req)
+	assert.Error(t, err)
+
+	output := buf.String()
+	assert.Contains(t, output, "failed")
+}
+
+func TestLoggingRoundTripper_NonVerbose_PassesThrough(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	rt := &loggingRoundTripper{base: http.DefaultTransport, verbose: false}
+	client := &http.Client{Transport: rt}
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+}
+
+func TestLoggingRoundTripper_NonVerbose_PropagatesError(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("transport error")
+	rt := &loggingRoundTripper{
+		base:    &errorTransport{err: wantErr},
+		verbose: false,
+	}
+	client := &http.Client{Transport: rt}
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost:1", nil)
+	_, err := client.Do(req)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+// errorTransport is a test double that always returns an error.
+type errorTransport struct {
+	err error
+}
+
+func (e *errorTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return nil, e.err
+}
+

--- a/report_test.go
+++ b/report_test.go
@@ -148,3 +148,175 @@ func TestSyncReport_WarningStruct(t *testing.T) {
 	assert.Equal(t, "Test Detail", warning.Detail)
 	assert.Equal(t, "Test Media", warning.MediaType)
 }
+
+// =============================================================================
+// AddUnmappedItems / HasUnmappedItems
+// =============================================================================
+
+func TestSyncReport_AddUnmappedItems(t *testing.T) {
+	t.Parallel()
+	report := NewSyncReport()
+
+	items := []UnmappedEntry{
+		{Title: "Anime A", AniListID: 1, MediaType: "anime"},
+		{Title: "Manga B", MALID: 2, MediaType: "manga"},
+	}
+	report.AddUnmappedItems(items)
+
+	assert.Len(t, report.UnmappedItems, 2)
+	assert.Equal(t, "Anime A", report.UnmappedItems[0].Title)
+	assert.Equal(t, "Manga B", report.UnmappedItems[1].Title)
+}
+
+func TestSyncReport_AddUnmappedItems_Empty(t *testing.T) {
+	t.Parallel()
+	report := NewSyncReport()
+	report.AddUnmappedItems(nil)
+	report.AddUnmappedItems([]UnmappedEntry{})
+
+	assert.Empty(t, report.UnmappedItems)
+}
+
+func TestSyncReport_AddUnmappedItems_Accumulates(t *testing.T) {
+	t.Parallel()
+	report := NewSyncReport()
+	report.AddUnmappedItems([]UnmappedEntry{{Title: "A"}})
+	report.AddUnmappedItems([]UnmappedEntry{{Title: "B"}, {Title: "C"}})
+
+	assert.Len(t, report.UnmappedItems, 3)
+}
+
+func TestSyncReport_HasUnmappedItems(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		setup    func(*SyncReport)
+		expected bool
+	}{
+		{"empty report", func(_ *SyncReport) {}, false},
+		{"one item", func(r *SyncReport) {
+			r.AddUnmappedItems([]UnmappedEntry{{Title: "X"}})
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSyncReport()
+			tt.setup(r)
+			assert.Equal(t, tt.expected, r.HasUnmappedItems())
+		})
+	}
+}
+
+// =============================================================================
+// AddDuplicateConflict / HasDuplicateConflicts
+// =============================================================================
+
+func TestSyncReport_AddDuplicateConflict(t *testing.T) {
+	t.Parallel()
+	report := NewSyncReport()
+
+	report.AddDuplicateConflict("Loser", "Winner", "Target", "stratA", "stratB", "anime")
+
+	assert.Len(t, report.DuplicateConflicts, 1)
+	c := report.DuplicateConflicts[0]
+	assert.Equal(t, "Loser", c.LoserTitle)
+	assert.Equal(t, "Winner", c.WinnerTitle)
+	assert.Equal(t, "Target", c.TargetTitle)
+	assert.Equal(t, "stratA", c.LoserStrat)
+	assert.Equal(t, "stratB", c.WinnerStrat)
+	assert.Equal(t, "anime", c.MediaType)
+}
+
+func TestSyncReport_AddDuplicateConflict_Multiple(t *testing.T) {
+	t.Parallel()
+	report := NewSyncReport()
+
+	report.AddDuplicateConflict("L1", "W1", "T1", "s1", "s2", "anime")
+	report.AddDuplicateConflict("L2", "W2", "T2", "s3", "s4", "manga")
+
+	assert.Len(t, report.DuplicateConflicts, 2)
+	assert.Equal(t, "L2", report.DuplicateConflicts[1].LoserTitle)
+}
+
+func TestSyncReport_HasDuplicateConflicts(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		setup    func(*SyncReport)
+		expected bool
+	}{
+		{"empty", func(_ *SyncReport) {}, false},
+		{"one conflict", func(r *SyncReport) {
+			r.AddDuplicateConflict("L", "W", "T", "s1", "s2", "anime")
+		}, true},
+		{"two conflicts", func(r *SyncReport) {
+			r.AddDuplicateConflict("L1", "W1", "T1", "s1", "s2", "anime")
+			r.AddDuplicateConflict("L2", "W2", "T2", "s3", "s4", "manga")
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSyncReport()
+			tt.setup(r)
+			assert.Equal(t, tt.expected, r.HasDuplicateConflicts())
+		})
+	}
+}
+
+// =============================================================================
+// AddFavoritesResult / HasFavoritesMismatches
+// =============================================================================
+
+func TestSyncReport_AddFavoritesResult(t *testing.T) {
+	t.Parallel()
+	report := NewSyncReport()
+
+	result := FavoritesResult{
+		Added: 3,
+		Mismatches: []FavoriteMismatch{
+			{Title: "Anime X", AniListID: 1, MALID: 10, MediaType: "anime", OnAniList: true, OnMAL: false},
+		},
+	}
+	report.AddFavoritesResult(result)
+
+	assert.Equal(t, 3, report.FavoritesAdded)
+	assert.Len(t, report.FavoritesMismatches, 1)
+	assert.Equal(t, "Anime X", report.FavoritesMismatches[0].Title)
+}
+
+func TestSyncReport_AddFavoritesResult_Accumulates(t *testing.T) {
+	t.Parallel()
+	report := NewSyncReport()
+
+	report.AddFavoritesResult(FavoritesResult{Added: 2, Mismatches: []FavoriteMismatch{{Title: "A"}}})
+	report.AddFavoritesResult(FavoritesResult{Added: 5, Mismatches: []FavoriteMismatch{{Title: "B"}, {Title: "C"}}})
+
+	assert.Equal(t, 7, report.FavoritesAdded)
+	assert.Len(t, report.FavoritesMismatches, 3)
+}
+
+func TestSyncReport_HasFavoritesMismatches(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		setup    func(*SyncReport)
+		expected bool
+	}{
+		{"empty", func(_ *SyncReport) {}, false},
+		{"only added, no mismatches", func(r *SyncReport) {
+			r.AddFavoritesResult(FavoritesResult{Added: 5})
+		}, false},
+		{"with mismatches", func(r *SyncReport) {
+			r.AddFavoritesResult(FavoritesResult{
+				Mismatches: []FavoriteMismatch{{Title: "X"}},
+			})
+		}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewSyncReport()
+			tt.setup(r)
+			assert.Equal(t, tt.expected, r.HasFavoritesMismatches())
+		})
+	}
+}

--- a/report_test.go
+++ b/report_test.go
@@ -320,3 +320,36 @@ func TestSyncReport_HasFavoritesMismatches(t *testing.T) {
 		})
 	}
 }
+
+// =============================================================================
+// Thread-safety: SyncReport mutex protection
+// =============================================================================
+
+func TestSyncReport_ConcurrentAccess(t *testing.T) {
+	// Run with -race to verify mutex protection on all Add/Has methods.
+	report := NewSyncReport()
+
+	const goroutines = 20
+	done := make(chan struct{})
+
+	for range goroutines {
+		go func() {
+			report.AddWarning("T", "r", "d", "anime")
+			report.AddDuplicateConflict("L", "W", "T", "s1", "s2", "anime")
+			report.AddUnmappedItems([]UnmappedEntry{{Title: "X"}})
+			report.AddFavoritesResult(FavoritesResult{Added: 1})
+			_ = report.HasWarnings()
+			_ = report.HasDuplicateConflicts()
+			_ = report.HasUnmappedItems()
+			_ = report.HasFavoritesMismatches()
+			done <- struct{}{}
+		}()
+	}
+
+	for range goroutines {
+		<-done
+	}
+
+	assert.Equal(t, goroutines, len(report.Warnings))
+	assert.Equal(t, goroutines, report.FavoritesAdded)
+}

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -547,3 +547,238 @@ func TestPrintGlobalSummary_WithDryRunItems(t *testing.T) {
 	output := buf.String()
 	assert.Contains(t, output, "Would update (2)")
 }
+
+// =============================================================================
+// RecordUpdate / RecordSkip / RecordError / IncrementTotal — extra coverage
+// =============================================================================
+
+func TestStatistics_RecordError_DoesNotUpdateStatusCounts(t *testing.T) {
+	t.Parallel()
+	stats := NewStatistics()
+
+	stats.RecordError(UpdateResult{Title: "Err1", Status: "watching", Error: errors.New("oops")})
+	stats.RecordError(UpdateResult{Title: "Err2", Status: "completed", Error: errors.New("fail")})
+
+	assert.Equal(t, 2, stats.ErrorCount)
+	assert.Len(t, stats.ErrorItems, 2)
+	// RecordError does NOT touch StatusCounts
+	assert.Empty(t, stats.StatusCounts)
+}
+
+func TestStatistics_RecordUpdate_TracksStatus(t *testing.T) {
+	t.Parallel()
+	stats := NewStatistics()
+
+	stats.RecordUpdate(UpdateResult{Title: "A", Status: "watching"})
+	stats.RecordUpdate(UpdateResult{Title: "B", Status: "watching"})
+	stats.RecordUpdate(UpdateResult{Title: "C", Status: "completed"})
+
+	assert.Equal(t, 3, stats.UpdatedCount)
+	assert.Len(t, stats.UpdatedItems, 3)
+	assert.Equal(t, 2, stats.StatusCounts["watching"])
+	assert.Equal(t, 1, stats.StatusCounts["completed"])
+}
+
+func TestStatistics_RecordSkip_TracksReason(t *testing.T) {
+	t.Parallel()
+	stats := NewStatistics()
+
+	stats.RecordSkip(UpdateResult{Title: "X", Status: "on_hold", SkipReason: "no changes"})
+	stats.RecordSkip(UpdateResult{Title: "Y", Status: "completed", SkipReason: "in ignore list"})
+
+	assert.Equal(t, 2, stats.SkippedCount)
+	assert.Len(t, stats.SkippedItems, 2)
+	assert.Equal(t, 1, stats.StatusCounts["on_hold"])
+	assert.Equal(t, 1, stats.StatusCounts["completed"])
+}
+
+// =============================================================================
+// aggregateStats
+// =============================================================================
+
+func TestAggregateStats(t *testing.T) {
+	t.Parallel()
+	s1 := NewStatistics()
+	s1.TotalCount = 10
+	s1.UpdatedCount = 3
+	s1.SkippedCount = 5
+	s1.ErrorCount = 2
+	s1.DryRunCount = 1
+	s1.SkippedItems = []UpdateResult{
+		{SkipReason: "no changes"},
+		{SkipReason: "no changes"},
+		{SkipReason: "unmapped"},
+	}
+	s1.UpdatedItems = []UpdateResult{{Title: "A"}}
+	s1.ErrorItems = []UpdateResult{{Title: "Err1"}}
+	s1.DryRunItems = []UpdateResult{{Title: "Dry1"}}
+
+	s2 := NewStatistics()
+	s2.TotalCount = 5
+	s2.UpdatedCount = 2
+	s2.SkippedCount = 2
+	s2.ErrorCount = 1
+	s2.DryRunCount = 0
+	s2.SkippedItems = []UpdateResult{{SkipReason: "no changes"}}
+	s2.UpdatedItems = []UpdateResult{{Title: "B"}}
+	s2.ErrorItems = []UpdateResult{{Title: "Err2"}}
+
+	result := aggregateStats([]*Statistics{s1, s2})
+
+	assert.Equal(t, 15, result.items)
+	assert.Equal(t, 5, result.updated)
+	assert.Equal(t, 7, result.skipped)
+	assert.Equal(t, 3, result.errors)
+	assert.Equal(t, 1, result.dryRun)
+	assert.Equal(t, 3, result.skipReasons["no changes"])
+	assert.Equal(t, 1, result.skipReasons["unmapped"])
+	assert.Len(t, result.updatedItems, 2)
+	assert.Len(t, result.errorItems, 2)
+	assert.Len(t, result.dryRunItems, 1)
+}
+
+func TestAggregateStats_NilEntries(t *testing.T) {
+	t.Parallel()
+	s := NewStatistics()
+	s.TotalCount = 7
+	s.UpdatedCount = 7
+
+	result := aggregateStats([]*Statistics{nil, s, nil})
+
+	assert.Equal(t, 7, result.items)
+	assert.Equal(t, 7, result.updated)
+}
+
+func TestAggregateStats_Empty(t *testing.T) {
+	t.Parallel()
+	result := aggregateStats([]*Statistics{})
+
+	assert.Equal(t, 0, result.items)
+	assert.Equal(t, 0, result.updated)
+	assert.Empty(t, result.skipReasons)
+}
+
+// =============================================================================
+// groupSkipReasons
+// =============================================================================
+
+func TestGroupSkipReasons(t *testing.T) {
+	t.Parallel()
+	items := []UpdateResult{
+		{SkipReason: "no changes"},
+		{SkipReason: "no changes"},
+		{SkipReason: "unmapped"},
+		{SkipReason: ""},
+	}
+
+	result := groupSkipReasons(items)
+
+	assert.Equal(t, 2, result["no changes"])
+	assert.Equal(t, 1, result["unmapped"])
+	assert.Equal(t, 1, result["unspecified"])
+	assert.Equal(t, 3, len(result))
+}
+
+func TestGroupSkipReasons_Empty(t *testing.T) {
+	t.Parallel()
+	result := groupSkipReasons(nil)
+	assert.Empty(t, result)
+}
+
+// =============================================================================
+// sortedKeys
+// =============================================================================
+
+func TestSortedKeys(t *testing.T) {
+	t.Parallel()
+	m := map[string]int{"banana": 1, "apple": 2, "cherry": 3}
+	keys := sortedKeys(m)
+	assert.Equal(t, []string{"apple", "banana", "cherry"}, keys)
+}
+
+func TestSortedKeys_Empty(t *testing.T) {
+	t.Parallel()
+	assert.Empty(t, sortedKeys(map[string]int{}))
+}
+
+func TestSortedKeys_SingleEntry(t *testing.T) {
+	t.Parallel()
+	keys := sortedKeys(map[string]int{"only": 1})
+	assert.Equal(t, []string{"only"}, keys)
+}
+
+// =============================================================================
+// capitalizeFirst
+// =============================================================================
+
+func TestCapitalizeFirst(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"anime", "Anime"},
+		{"manga", "Manga"},
+		{"ALREADY", "ALREADY"},
+		{"", ""},
+		{"a", "A"},
+		{"already Capitalized", "Already Capitalized"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, capitalizeFirst(tt.input))
+		})
+	}
+}
+
+// =============================================================================
+// formatUnmappedLine
+// =============================================================================
+
+func TestFormatUnmappedLine(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		num      int
+		item     UnmappedEntry
+		media    string
+		contains []string
+	}{
+		{
+			name:     "with AniList ID",
+			num:      1,
+			item:     UnmappedEntry{Title: "Naruto", AniListID: 100, Reason: "no match"},
+			media:    "Anime",
+			contains: []string{"1.", `"Naruto"`, "AniList: 100", "[Anime]", "no match"},
+		},
+		{
+			name:     "with MAL ID",
+			num:      2,
+			item:     UnmappedEntry{Title: "Bleach", MALID: 200},
+			media:    "Anime",
+			contains: []string{"2.", `"Bleach"`, "MAL: 200"},
+		},
+		{
+			name:     "with neither ID",
+			num:      3,
+			item:     UnmappedEntry{Title: "Unknown", Reason: "missing"},
+			media:    "Manga",
+			contains: []string{"3.", `"Unknown"`, "[Manga]", "missing"},
+		},
+		{
+			name:     "no reason",
+			num:      4,
+			item:     UnmappedEntry{Title: "X", AniListID: 5},
+			media:    "Anime",
+			contains: []string{`"X"`, "AniList: 5"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatUnmappedLine(tt.num, tt.item, tt.media)
+			for _, want := range tt.contains {
+				assert.Contains(t, got, want)
+			}
+		})
+	}
+}

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -598,38 +598,33 @@ func TestStatistics_RecordSkip_TracksReason(t *testing.T) {
 
 func TestAggregateStats(t *testing.T) {
 	t.Parallel()
+
+	// Build s1 via the public API so counts and item slices stay consistent.
 	s1 := NewStatistics()
-	s1.TotalCount = 10
-	s1.UpdatedCount = 3
-	s1.SkippedCount = 5
-	s1.ErrorCount = 2
-	s1.DryRunCount = 1
-	s1.SkippedItems = []UpdateResult{
-		{SkipReason: "no changes"},
-		{SkipReason: "no changes"},
-		{SkipReason: "unmapped"},
-	}
-	s1.UpdatedItems = []UpdateResult{{Title: "A"}}
-	s1.ErrorItems = []UpdateResult{{Title: "Err1"}}
-	s1.DryRunItems = []UpdateResult{{Title: "Dry1"}}
+	s1.IncrementTotal()
+	s1.IncrementTotal()
+	s1.IncrementTotal()
+	s1.RecordUpdate(UpdateResult{Title: "A", Status: "watching"})
+	s1.RecordSkip(UpdateResult{SkipReason: "no changes", Status: "completed"})
+	s1.RecordSkip(UpdateResult{SkipReason: "no changes", Status: "completed"})
+	s1.RecordSkip(UpdateResult{SkipReason: "unmapped", Status: "completed"})
+	s1.RecordError(UpdateResult{Title: "Err1"})
+	s1.RecordDryRun(UpdateResult{Title: "Dry1", Status: "watching"})
 
 	s2 := NewStatistics()
-	s2.TotalCount = 5
-	s2.UpdatedCount = 2
-	s2.SkippedCount = 2
-	s2.ErrorCount = 1
-	s2.DryRunCount = 0
-	s2.SkippedItems = []UpdateResult{{SkipReason: "no changes"}}
-	s2.UpdatedItems = []UpdateResult{{Title: "B"}}
-	s2.ErrorItems = []UpdateResult{{Title: "Err2"}}
+	s2.IncrementTotal()
+	s2.IncrementTotal()
+	s2.RecordUpdate(UpdateResult{Title: "B", Status: "watching"})
+	s2.RecordSkip(UpdateResult{SkipReason: "no changes", Status: "watching"})
+	s2.RecordError(UpdateResult{Title: "Err2"})
 
 	result := aggregateStats([]*Statistics{s1, s2})
 
-	assert.Equal(t, 15, result.items)
-	assert.Equal(t, 5, result.updated)
-	assert.Equal(t, 7, result.skipped)
-	assert.Equal(t, 3, result.errors)
-	assert.Equal(t, 1, result.dryRun)
+	assert.Equal(t, 5, result.items)   // 3 + 2 IncrementTotal calls
+	assert.Equal(t, 2, result.updated) // 1 + 1
+	assert.Equal(t, 4, result.skipped) // 3 + 1
+	assert.Equal(t, 2, result.errors)  // 1 + 1
+	assert.Equal(t, 1, result.dryRun)  // 1 + 0
 	assert.Equal(t, 3, result.skipReasons["no changes"])
 	assert.Equal(t, 1, result.skipReasons["unmapped"])
 	assert.Len(t, result.updatedItems, 2)
@@ -714,18 +709,19 @@ func TestSortedKeys_SingleEntry(t *testing.T) {
 func TestCapitalizeFirst(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
+		name     string
 		input    string
 		expected string
 	}{
-		{"anime", "Anime"},
-		{"manga", "Manga"},
-		{"ALREADY", "ALREADY"},
-		{"", ""},
-		{"a", "A"},
-		{"already Capitalized", "Already Capitalized"},
+		{"lowercase word", "anime", "Anime"},
+		{"another word", "manga", "Manga"},
+		{"already upper", "ALREADY", "ALREADY"},
+		{"empty string", "", ""},
+		{"single char", "a", "A"},
+		{"mixed case", "already Capitalized", "Already Capitalized"},
 	}
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, capitalizeFirst(tt.input))
 		})
 	}


### PR DESCRIPTION
When AniList returns HTTP 429 Too Many Requests, the response includes a
Retry-After header indicating how many seconds to wait before retrying.
The previous exponential backoff (1s/2s/4s) was far too short for AniList's
typical rate limit window (~60s), causing all retries to fail and
producing cascading 429 errors across subsequent entries.

The new retryAfterOrBackoff function reads the Retry-After header on 429
responses and uses it as the wait duration, falling back to exponential
backoff when the header is absent or unparseable.

Fixes #68

https://claude.ai/code/session_01URgcG3tnisQpFGV6ybxJJ3