### PR TITLE
ci: pin GitHub Actions to commit SHAs to prevent supply chain attacks

### DIFF
--- a/.github/workflows/cleanup-pr-caches.yml
+++ b/.github/workflows/cleanup-pr-caches.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Delete PR branch caches
         env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,25 +36,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -64,14 +64,14 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       # Build Docker image
       - name: Build Docker image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           push: false
@@ -86,7 +86,7 @@ jobs:
       - name: Push Docker image
         id: push
         if: ${{ github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.') }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           push: true

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
           cache: true
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         with:
           files: ./coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -40,13 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
           cache: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: v2.10.1
           only-new-issues: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,12 +24,12 @@ jobs:
           - goarch: arm64
             goos: windows
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version: "1.25"
           cache: true
-      - uses: wangyoucao577/go-release-action@v1
+      - uses: wangyoucao577/go-release-action@279495102627de7960cbc33434ab01a12bae144b # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           goos: ${{ matrix.goos }}


### PR DESCRIPTION
## Problem

All GitHub Actions workflows used major version tags (`@v6`, `@v7`, etc.) instead of pinned commit SHAs. This creates a supply chain attack vector: if an action maintainer's account is compromised and the tag is moved to a malicious commit, CI will automatically execute that malicious code with the workflow's permissions.

## Changes

All `uses:` entries are now pinned to a full commit SHA with the original tag preserved as a comment:

| Action | Tag | SHA |
|---|---|---|
| `actions/checkout` | `v6` | `de0fac2e` |
| `actions/setup-go` | `v6` | `4a360112` |
| `docker/setup-buildx-action` | `v4` | `d7f5e7f5` |
| `docker/login-action` | `v4` | `650006c6` |
| `docker/metadata-action` | `v6` | `80c7e94d` |
| `docker/build-push-action` | `v7` | `f9f3042f` |
| `sigstore/cosign-installer` | `v3` | `398d4b0e` |
| `golangci/golangci-lint-action` | `v9` | `82606bf2` |
| `codecov/codecov-action` | `v6` | `e79a6962` |
| `wangyoucao577/go-release-action` | `v1` | `27949510` |

## Affected files

- `.github/workflows/cleanup-pr-caches.yml`
- `.github/workflows/docker-publish.yml`
- `.github/workflows/go.yaml`
- `.github/workflows/golangci-lint.yaml`
- `.github/workflows/release.yaml`