### PR TITLE
fix(jikan): respect both documented rate limits and surface throttling

### DIFF
--- a/http_retry.go
+++ b/http_retry.go
@@ -2,12 +2,15 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -53,15 +56,41 @@ func shouldRetryStatus(statusCode int) bool {
 // isRetryable determines if an error or response should trigger a retry.
 func isRetryable(err error, resp *http.Response) bool {
 	if err != nil {
-		errStr := err.Error()
-		return strings.Contains(errStr, "connection refused") ||
-			strings.Contains(errStr, "connection reset") ||
-			strings.Contains(errStr, "broken pipe")
+		return isTransientNetworkError(err)
 	}
 	if resp == nil {
 		return false
 	}
 	return shouldRetryStatus(resp.StatusCode)
+}
+
+// isTransientNetworkError reports whether a transport error is worth retrying.
+// A per-attempt timeout counts: slow upstreams (Jikan proxies MyAnimeList)
+// routinely stall on one connection and answer on the next.
+func isTransientNetworkError(err error) bool {
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	switch {
+	case errors.Is(err, syscall.ECONNREFUSED),
+		errors.Is(err, syscall.ECONNRESET),
+		errors.Is(err, syscall.EPIPE),
+		errors.Is(err, io.EOF),
+		errors.Is(err, io.ErrUnexpectedEOF):
+		return true
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	// Transports that only carry a message (test doubles, wrapped strings).
+	errStr := err.Error()
+	return strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "connection reset") ||
+		strings.Contains(errStr, "broken pipe")
 }
 
 // cloneRequest creates a copy of an HTTP request, including its body.
@@ -112,6 +141,7 @@ func executeWithRetry(
 	doRequest func(*http.Request) (*http.Response, error),
 ) (*http.Response, error) {
 	var lastErr error
+	var lastStatus int
 	var nextWait time.Duration
 	var rateLimited bool
 
@@ -149,6 +179,7 @@ func executeWithRetry(
 		}
 
 		if resp != nil {
+			lastStatus = resp.StatusCode
 			_ = resp.Body.Close()
 		}
 
@@ -166,6 +197,12 @@ func executeWithRetry(
 
 	if lastErr != nil {
 		return nil, lastErr
+	}
+	// Keep the status: callers must be able to tell rate limiting (429)
+	// from an upstream outage (5xx) after the response body is gone.
+	if lastStatus != 0 {
+		return nil, fmt.Errorf("max retries (%d) exhausted, last status: %d %s",
+			maxRetries, lastStatus, http.StatusText(lastStatus))
 	}
 	return nil, fmt.Errorf("max retries (%d) exhausted", maxRetries)
 }

--- a/http_retry.go
+++ b/http_retry.go
@@ -187,11 +187,10 @@ func executeWithRetry(
 			lastErr = err
 		}
 
+		// A retryable status never reaches here, so only a transport
+		// error can be permanent at this point.
 		if !isRetryable(err, resp) {
-			if err != nil {
-				return nil, err
-			}
-			return resp, nil
+			return nil, err
 		}
 	}
 
@@ -200,11 +199,8 @@ func executeWithRetry(
 	}
 	// Keep the status: callers must be able to tell rate limiting (429)
 	// from an upstream outage (5xx) after the response body is gone.
-	if lastStatus != 0 {
-		return nil, fmt.Errorf("max retries (%d) exhausted, last status: %d %s",
-			maxRetries, lastStatus, http.StatusText(lastStatus))
-	}
-	return nil, fmt.Errorf("max retries (%d) exhausted", maxRetries)
+	return nil, fmt.Errorf("max retries (%d) exhausted, last status: %d %s",
+		maxRetries, lastStatus, http.StatusText(lastStatus))
 }
 
 // parseRetryAfter parses the value of a Retry-After header per RFC 7231 §7.1.3.

--- a/http_retry_test.go
+++ b/http_retry_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -742,5 +745,59 @@ func TestExecuteWithRetry_SkipsBackoffOnLastAttempt(t *testing.T) {
 	// The last attempt (3 == maxRetries) must NOT trigger a backoff call.
 	if cb.calls != maxRetries {
 		t.Fatalf("expected %d backoff calls, got %d", maxRetries, cb.calls)
+	}
+}
+
+// =============================================================================
+// executeWithRetry — exhausted retries keep the status visible
+// =============================================================================
+
+func TestExecuteWithRetry_ExhaustedRetriesReportStatus(t *testing.T) {
+	t.Parallel()
+
+	doRequest := func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://localhost:1", nil)
+	resp, err := executeWithRetry(req, 2, &countingBackoff{}, doRequest)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	if err == nil {
+		t.Fatal("expected an error after retries are exhausted")
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Fatalf("expected the 429 status in the error, got %q", err)
+	}
+}
+
+func TestIsRetryable_TypedNetworkErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{name: "connection reset syscall", err: syscall.ECONNRESET, expected: true},
+		{name: "unexpected EOF", err: io.ErrUnexpectedEOF, expected: true},
+		{name: "timeout", err: &net.DNSError{IsTimeout: true}, expected: true},
+		{name: "wrapped timeout", err: fmt.Errorf("get: %w", &net.DNSError{IsTimeout: true}), expected: true},
+		{name: "context canceled", err: context.Canceled, expected: false},
+		{name: "dns not found", err: &net.DNSError{IsNotFound: true}, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isRetryable(tt.err, nil); got != tt.expected {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+		})
 	}
 }

--- a/jikan_api.go
+++ b/jikan_api.go
@@ -13,8 +13,19 @@ import (
 
 const (
 	defaultJikanBaseURL     = "https://api.jikan.moe/v4"
-	defaultJikanCacheMaxAge = 168 * time.Hour        // 7 days
-	jikanMinRequestInterval = 500 * time.Millisecond // ~2 req/s (conservative, Jikan limit is 3 req/s)
+	defaultJikanCacheMaxAge = 168 * time.Hour // 7 days
+
+	// Documented Jikan v4 limits: 3 requests/second AND 60 requests/minute.
+	// The per-minute cap binds first — honouring only the per-second one
+	// exceeds the quota after ~30 seconds of steady traffic.
+	jikanMinRequestInterval = 340 * time.Millisecond
+	jikanRequestsPerMinute  = 60
+	jikanMinuteWindow       = time.Minute
+
+	// Rate-limit windows reset in tens of seconds, so a 429 needs more
+	// than the two attempts the other clients get.
+	jikanMaxRetries            = 4
+	jikanResponseHeaderTimeout = 20 * time.Second
 )
 
 // JikanMangaData contains the manga data we extract from Jikan API responses.
@@ -60,10 +71,6 @@ type JikanClient struct {
 	baseURL    string
 	httpClient HTTPClient
 	cache      *JikanCache
-
-	// Rate limiting
-	rateMu      sync.Mutex
-	lastRequest time.Time
 }
 
 // NewJikanClient creates a new Jikan API client with caching.
@@ -77,24 +84,85 @@ func NewJikanClient(ctx context.Context, cacheDir string, cacheMaxAgeStr string)
 	LogInfoSuccess(ctx, "Jikan cache loaded (%d entries)", cache.Size())
 
 	return &JikanClient{
-		baseURL: defaultJikanBaseURL,
-		httpClient: NewRetryableClient(&http.Client{
-			Timeout: 15 * time.Second,
-		}, 2),
-		cache: cache,
+		baseURL:    defaultJikanBaseURL,
+		httpClient: newJikanHTTPClient(),
+		cache:      cache,
 	}
 }
 
-// rateLimit waits if needed to respect rate limits.
-func (c *JikanClient) rateLimit() {
-	c.rateMu.Lock()
-	defer c.rateMu.Unlock()
+// newJikanHTTPClient stacks the retry logic ON TOP of the rate limiter, so
+// every attempt — retries included — consumes a quota slot. A client-wide
+// timeout is deliberately absent: it would cover the whole retry sequence,
+// including backoff sleeps. Each attempt is bounded by the transport instead.
+func newJikanHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone() //nolint:forcetypeassert // stdlib guarantees the concrete type
+	transport.ResponseHeaderTimeout = jikanResponseHeaderTimeout
 
-	elapsed := time.Since(c.lastRequest)
-	if elapsed < jikanMinRequestInterval {
-		time.Sleep(jikanMinRequestInterval - elapsed)
+	limited := &http.Client{Transport: &jikanRateLimiter{underlying: transport}}
+
+	return &http.Client{Transport: NewRetryableTransport(limited, jikanMaxRetries)}
+}
+
+// jikanRateLimiter paces outgoing requests to stay inside both documented
+// Jikan quotas at once: a minimum gap between requests and a rolling minute.
+type jikanRateLimiter struct {
+	underlying http.RoundTripper
+
+	mu   sync.Mutex
+	sent []time.Time // send times inside the trailing minute, oldest first
+}
+
+func (l *jikanRateLimiter) RoundTrip(req *http.Request) (*http.Response, error) {
+	wait := l.reserve(time.Now())
+	if wait <= 0 {
+		return l.underlying.RoundTrip(req)
 	}
-	c.lastRequest = time.Now()
+
+	LogDebug(req.Context(), "[JIKAN RATE] waiting %v before %s", wait, req.URL)
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+	case <-req.Context().Done():
+		return nil, req.Context().Err()
+	}
+
+	return l.underlying.RoundTrip(req)
+}
+
+// reserve claims the next send slot and reports how long to wait for it.
+func (l *jikanRateLimiter) reserve(now time.Time) time.Duration {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	sendAt := now
+	if len(l.sent) > 0 {
+		if next := l.sent[len(l.sent)-1].Add(jikanMinRequestInterval); next.After(sendAt) {
+			sendAt = next
+		}
+	}
+	if len(l.sent) >= jikanRequestsPerMinute {
+		// Wait for the oldest of the last N sends to leave the window.
+		if freed := l.sent[len(l.sent)-jikanRequestsPerMinute].Add(jikanMinuteWindow); freed.After(sendAt) {
+			sendAt = freed
+		}
+	}
+
+	l.sent = append(l.sent, sendAt)
+	l.sent = droppedBefore(l.sent, sendAt.Add(-jikanMinuteWindow))
+
+	return sendAt.Sub(now)
+}
+
+// droppedBefore returns the tail of times that is newer than cutoff.
+func droppedBefore(times []time.Time, cutoff time.Time) []time.Time {
+	i := 0
+	for i < len(times) && !times[i].After(cutoff) {
+		i++
+	}
+	return times[i:]
 }
 
 // GetMangaByMALID retrieves manga data by MAL ID, checking cache first.
@@ -122,11 +190,11 @@ func (c *JikanClient) GetMangaByMALID(ctx context.Context, malID int) (*JikanMan
 	apiURL := fmt.Sprintf("%s/manga/%d", c.baseURL, malID)
 	LogDebug(ctx, "[JIKAN API] GET %s", apiURL)
 
-	c.rateLimit()
-
 	resp, err := c.doRequest(ctx, apiURL)
 	if err != nil {
-		LogDebug(ctx, "[JIKAN API] manga %d: error: %v", malID, err)
+		// A failed lookup is indistinguishable from "no such manga" downstream,
+		// so surface it — silent rate limiting degrades matching quality.
+		LogWarn(ctx, "[JIKAN API] manga %d: %v", malID, err)
 		return nil, false
 	}
 	if resp == nil {
@@ -175,11 +243,9 @@ func (c *JikanClient) SearchManga(ctx context.Context, query string) []JikanMang
 	apiURL := fmt.Sprintf("%s/manga?%s", c.baseURL, params.Encode())
 	LogDebug(ctx, "[JIKAN API] GET %s", apiURL)
 
-	c.rateLimit()
-
 	resp, err := c.doRequest(ctx, apiURL)
 	if err != nil {
-		LogDebug(ctx, "[JIKAN API] search %q: error: %v", query, err)
+		LogWarn(ctx, "[JIKAN API] search %q: %v", query, err)
 		return nil
 	}
 	if resp == nil {
@@ -215,15 +281,13 @@ func (c *JikanClient) GetUserFavorites(ctx context.Context, username string) (
 	apiURL := fmt.Sprintf("%s/users/%s/favorites", c.baseURL, url.PathEscape(username))
 	LogDebug(ctx, "[JIKAN API] GET %s", apiURL)
 
-	c.rateLimit()
-
 	resp, err := c.doRequest(ctx, apiURL)
 	if err != nil {
-		LogDebug(ctx, "[JIKAN API] user %s favorites: error: %v", username, err)
 		return nil, nil, fmt.Errorf("failed to fetch user favorites: %w", err)
 	}
 	if resp == nil {
-		return nil, nil, fmt.Errorf("user %s not found or profile is private", username)
+		// Jikan answers 404 both for an unknown user and for a MyAnimeList error.
+		return nil, nil, fmt.Errorf("user %s not found, profile is private, or MyAnimeList rejected the lookup", username)
 	}
 	defer resp.Body.Close() //nolint:errcheck // best effort close
 

--- a/jikan_api_test.go
+++ b/jikan_api_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -515,4 +518,266 @@ func TestJikanRateLimiter_NoWaitAfterIdlePeriod(t *testing.T) {
 	}
 
 	assert.Equal(t, time.Duration(0), limiter.reserve(now.Add(2*jikanMinuteWindow)))
+}
+
+func closeBody(t *testing.T, resp *http.Response) {
+	t.Helper()
+	if resp != nil {
+		assert.NoError(t, resp.Body.Close())
+	}
+}
+
+// stubRoundTripper counts the requests it serves and answers each with a fresh 200.
+type stubRoundTripper struct {
+	calls int
+}
+
+func (s *stubRoundTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	s.calls++
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("{}")),
+	}, nil
+}
+
+func TestJikanRateLimiter_RoundTripPassesFirstRequestThrough(t *testing.T) {
+	t.Parallel()
+	stub := &stubRoundTripper{}
+	limiter := &jikanRateLimiter{underlying: stub}
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.test/manga/1", nil)
+	resp, err := limiter.RoundTrip(req)
+	defer closeBody(t, resp)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 1, stub.calls)
+}
+
+func TestJikanRateLimiter_RoundTripWaitsBetweenRequests(t *testing.T) {
+	t.Parallel()
+	stub := &stubRoundTripper{}
+	limiter := &jikanRateLimiter{underlying: stub}
+
+	req, _ := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://example.test/manga/1", nil)
+	first, err := limiter.RoundTrip(req)
+	defer closeBody(t, first)
+	assert.NoError(t, err)
+
+	start := time.Now()
+	second, err := limiter.RoundTrip(req)
+	elapsed := time.Since(start)
+	defer closeBody(t, second)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 2, stub.calls)
+	// Timer granularity keeps this slightly under the nominal interval.
+	assert.GreaterOrEqual(t, elapsed, jikanMinRequestInterval-20*time.Millisecond)
+}
+
+func TestJikanRateLimiter_RoundTripAbortsOnCanceledContext(t *testing.T) {
+	t.Parallel()
+	stub := &stubRoundTripper{}
+	limiter := &jikanRateLimiter{underlying: stub}
+
+	// Exhaust the minute quota so the next request faces a minute-long wait.
+	now := time.Now()
+	for range jikanRequestsPerMinute {
+		limiter.reserve(now)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://example.test/manga/1", nil)
+
+	resp, err := limiter.RoundTrip(req) //nolint:bodyclose // no response on a canceled request
+
+	assert.Nil(t, resp)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 0, stub.calls, "the request must not reach the network")
+}
+
+func TestNewJikanHTTPClient_RetriesAboveRateLimiter(t *testing.T) {
+	t.Parallel()
+	client := newJikanHTTPClient()
+
+	retryable, ok := client.Transport.(*retryableRoundTripper)
+	assert.True(t, ok, "the outer transport must apply retries")
+	assert.Equal(t, jikanMaxRetries, retryable.maxRetries)
+	assert.Zero(t, client.Timeout, "a client-wide timeout would also cap the backoff sleeps")
+
+	// Retries must pass through the limiter, otherwise they escape the quota.
+	_, ok = retryable.underlying.(*jikanRateLimiter)
+	assert.True(t, ok, "the retry transport must wrap the rate limiter")
+}
+
+func TestNewJikanClient_UsesDefaultEndpointAndSavesCache(t *testing.T) {
+	t.Parallel()
+	client := NewJikanClient(t.Context(), t.TempDir(), "1h")
+
+	assert.Equal(t, defaultJikanBaseURL, client.baseURL)
+	assert.NotNil(t, client.httpClient)
+	assert.NoError(t, client.SaveCache(t.Context()))
+}
+
+func TestJikanClient_GetUserFavorites(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/users/tester/favorites", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				mediaTypeAnime: []map[string]any{{"mal_id": 1, "title": "Anime One"}},
+				mediaTypeManga: []map[string]any{{"mal_id": 7, "title": "Manga Seven"}, {"mal_id": 9, "title": "Manga Nine"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := newTestJikanClient(t, server.URL, t.TempDir())
+	animeIDs, mangaIDs, err := client.GetUserFavorites(t.Context(), "tester")
+
+	assert.NoError(t, err)
+	assert.Equal(t, map[int]struct{}{1: {}}, animeIDs)
+	assert.Equal(t, map[int]struct{}{7: {}, 9: {}}, mangaIDs)
+}
+
+func TestJikanClient_GetUserFavorites_Failures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		username    string
+		status      int
+		body        string
+		wantMessage string
+	}{
+		{
+			name:        "empty username is rejected before any request",
+			username:    "",
+			status:      http.StatusOK,
+			body:        "{}",
+			wantMessage: "username cannot be empty",
+		},
+		{
+			name:        "404 covers unknown, private and upstream-rejected users",
+			username:    "ghost",
+			status:      http.StatusNotFound,
+			body:        "{}",
+			wantMessage: "not found, profile is private, or MyAnimeList rejected the lookup",
+		},
+		{
+			name:        "unexpected status is reported, not swallowed",
+			username:    "tester",
+			status:      http.StatusTooManyRequests,
+			body:        "{}",
+			wantMessage: "failed to fetch user favorites",
+		},
+		{
+			name:        "malformed payload is reported",
+			username:    "tester",
+			status:      http.StatusOK,
+			body:        "{not json",
+			wantMessage: "failed to decode favorites response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := newTestJikanClient(t, server.URL, t.TempDir())
+			animeIDs, mangaIDs, err := client.GetUserFavorites(t.Context(), tt.username)
+
+			assert.Nil(t, animeIDs)
+			assert.Nil(t, mangaIDs)
+			assert.ErrorContains(t, err, tt.wantMessage)
+		})
+	}
+}
+
+func TestJikanClient_MalformedPayloadIsNotCached(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("{not json"))
+	}))
+	defer server.Close()
+
+	client := newTestJikanClient(t, server.URL, t.TempDir())
+
+	manga, found := client.GetMangaByMALID(t.Context(), 42)
+	assert.Nil(t, manga)
+	assert.False(t, found)
+
+	assert.Nil(t, client.SearchManga(t.Context(), "berserk"))
+
+	// A decode failure is not an answer — it must not poison the cache.
+	_, cached := client.cache.Get(42)
+	assert.False(t, cached)
+}
+
+func TestJikanClient_SearchManga_NotFound(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := newTestJikanClient(t, server.URL, t.TempDir())
+
+	assert.Nil(t, client.SearchManga(t.Context(), "nothing here"))
+}
+
+func TestJikanClient_DoRequest_InvalidURL(t *testing.T) {
+	t.Parallel()
+	client := newTestJikanClient(t, "http://example.test", t.TempDir())
+
+	resp, err := client.doRequest(t.Context(), "http://exa mple.test/manga/1") //nolint:bodyclose // no response on a malformed URL
+
+	assert.Nil(t, resp)
+	assert.ErrorContains(t, err, "create request")
+}
+
+func TestMatchJikanMangaToSource_CrossMatchesRomajiAgainstEnglish(t *testing.T) {
+	t.Parallel()
+	jikanData := &JikanMangaData{
+		MalID:        1,
+		Title:        "totally different",
+		TitleEnglish: "Vinland Saga",
+	}
+
+	assert.True(t, matchJikanMangaToSource(t.Context(), jikanData, "", "", "Vinland Saga"))
+	assert.False(t, matchJikanMangaToSource(t.Context(), jikanData, "", "", "Berserk"))
+}
+
+func TestJikanClient_SearchManga_RateLimited(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := newTestJikanClient(t, server.URL, t.TempDir())
+
+	// A quota failure yields no results and, unlike a 404, is not cached.
+	assert.Nil(t, client.SearchManga(t.Context(), "berserk"))
+	_, cached := client.cache.GetSearch("berserk")
+	assert.False(t, cached)
+}
+
+func TestJikanClient_DoRequest_TransportError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	unreachableURL := server.URL
+	server.Close()
+
+	client := newTestJikanClient(t, unreachableURL, t.TempDir())
+	resp, err := client.doRequest(t.Context(), unreachableURL+"/manga/1") //nolint:bodyclose // no response when the dial fails
+
+	assert.Nil(t, resp)
+	assert.ErrorContains(t, err, "request")
 }

--- a/jikan_api_test.go
+++ b/jikan_api_test.go
@@ -474,3 +474,45 @@ func TestJikanClient_ServerError(t *testing.T) {
 	assert.False(t, found)
 	assert.Nil(t, data)
 }
+
+// =============================================================================
+// Rate limiter — both documented Jikan quotas
+// =============================================================================
+
+func TestJikanRateLimiter_SpacesConsecutiveRequests(t *testing.T) {
+	t.Parallel()
+	limiter := &jikanRateLimiter{}
+	now := time.Now()
+
+	assert.Equal(t, time.Duration(0), limiter.reserve(now))
+	assert.Equal(t, jikanMinRequestInterval, limiter.reserve(now))
+	assert.Equal(t, 2*jikanMinRequestInterval, limiter.reserve(now))
+}
+
+func TestJikanRateLimiter_HonoursMinuteQuota(t *testing.T) {
+	t.Parallel()
+	limiter := &jikanRateLimiter{}
+	now := time.Now()
+
+	var last time.Duration
+	for range jikanRequestsPerMinute {
+		last = limiter.reserve(now)
+	}
+	// The per-second gap alone would let all 60 through in ~20s.
+	assert.Less(t, last, jikanMinuteWindow)
+
+	// One past the quota must wait for the oldest send to leave the window.
+	assert.Equal(t, jikanMinuteWindow, limiter.reserve(now))
+}
+
+func TestJikanRateLimiter_NoWaitAfterIdlePeriod(t *testing.T) {
+	t.Parallel()
+	limiter := &jikanRateLimiter{}
+	now := time.Now()
+
+	for range jikanRequestsPerMinute {
+		limiter.reserve(now)
+	}
+
+	assert.Equal(t, time.Duration(0), limiter.reserve(now.Add(2*jikanMinuteWindow)))
+}


### PR DESCRIPTION
**Context** — Jikan documents two rate limits that apply at the same time: 3 requests/second and 60 requests/minute. The client honoured only the per-second one, pacing requests 500ms apart. That is 120 requests per minute against a ceiling of 60, so any sync running against a cold cache started collecting `429`s after roughly half a minute. The rate limiting was also invisible afterwards: once retries were exhausted the response had already been closed, the caller received a bare "max retries exhausted", and the Jikan lookups logged it at debug level before returning "not found". A throttled sync therefore looked exactly like a sync where the entries genuinely had no match, and silently produced worse matching.

```
before:  rateLimit()  →  retry  →  [attempt] [retry] [retry]   retries bypass the quota
after:   retry  →  rateLimiter  →  [attempt]                   every attempt takes a slot
```

**Scope**
- Pace requests against both documented quotas — a minimum gap plus a rolling one-minute window.
- Move the limiter underneath the retry transport, so retried attempts consume quota slots instead of escaping the accounting.
- Bound each attempt at the transport rather than with a client-wide timeout, which also covered the backoff sleeps between attempts.
- Raise the Jikan retry budget, since a quota window resets in tens of seconds.
- Report the failing status when retries run out, and log failed lookups as warnings rather than debug noise.
- Retry transient transport errors — per-attempt timeouts, resets and unexpected EOFs were previously matched by three hardcoded substrings and otherwise treated as permanent.
- Cover the pacing, the favorites endpoint and every non-200 branch with unit tests; the quota logic is driven by a synthetic clock, so the suite does not sleep through it.

**Impact** — Syncs with a cold Jikan cache stay inside the published quota instead of exceeding it twofold, and a throttled or failing lookup is now visible in the log rather than being reported as an unmatched entry. Retry behaviour for the other API clients is unchanged apart from the wider transient-error matching. `jikan_api.go` and `http_retry.go` are at 100% statement coverage.
