### PR TITLE
Bound MyAnimeList list updates by the HTTP timeout

### DIFF
--- a/myanimelist.go
+++ b/myanimelist.go
@@ -79,6 +79,8 @@ func (c *MyAnimeListClient) UpdateAnimeByIDAndOptions(ctx context.Context, id in
 	// Log update details for debugging
 	LogDebug(ctx, "[MAL] Updating MAL ID %d with opts: %+v", id, opts)
 
+	ctx, cancel := withTimeout(ctx, c.httpTimeout)
+	defer cancel()
 	_, _, err := c.c.Anime.UpdateMyListStatus(ctx, id, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to update anime %d: %w", id, err)
@@ -119,6 +121,8 @@ func (c *MyAnimeListClient) UpdateMangaByIDAndOptions(ctx context.Context, id in
 		return nil
 	}
 
+	ctx, cancel := withTimeout(ctx, c.httpTimeout)
+	defer cancel()
 	_, _, err := c.c.Manga.UpdateMyListStatus(ctx, id, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to update manga %d: %w", id, err)

--- a/myanimelist_test.go
+++ b/myanimelist_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/nstratos/go-myanimelist/mal"
+	"github.com/stretchr/testify/assert"
+)
+
+// newStalledMALClient points a MAL client at a server that never answers, so a
+// call can only return by hitting its own timeout.
+func newStalledMALClient(t *testing.T, timeout time.Duration) *MyAnimeListClient {
+	t.Helper()
+
+	// Released at cleanup: a handler parked on the request context alone would
+	// keep Close waiting on a connection the client has already abandoned.
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(release)
+		server.Close()
+	})
+
+	base, err := url.Parse(server.URL + "/")
+	assert.NoError(t, err)
+
+	client := mal.NewClient(nil)
+	client.BaseURL = base
+
+	// username is unused by the update calls under test.
+	return &MyAnimeListClient{c: client, httpTimeout: timeout}
+}
+
+// A stalled write used to hang forever: the update calls were the only ones
+// that never wrapped the context in a timeout.
+func TestMyAnimeListClient_UpdateAnimeByIDAndOptions_TimesOut(t *testing.T) {
+	t.Parallel()
+
+	client := newStalledMALClient(t, 100*time.Millisecond)
+
+	start := time.Now()
+	err := client.UpdateAnimeByIDAndOptions(t.Context(), 164, []mal.UpdateMyAnimeListStatusOption{
+		mal.AnimeStatusCompleted,
+	})
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 5*time.Second, "must give up on its own timeout")
+}
+
+func TestMyAnimeListClient_UpdateMangaByIDAndOptions_TimesOut(t *testing.T) {
+	t.Parallel()
+
+	client := newStalledMALClient(t, 100*time.Millisecond)
+
+	start := time.Now()
+	err := client.UpdateMangaByIDAndOptions(t.Context(), 164, []mal.UpdateMyMangaListStatusOption{
+		mal.MangaStatusCompleted,
+	})
+
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Less(t, time.Since(start), 5*time.Second, "must give up on its own timeout")
+}


### PR DESCRIPTION
**Context** — A real sync stalled for ten minutes on a single list update and then failed, leaving the entry unsynced. Every read call against MyAnimeList wraps the caller context in the configured HTTP timeout, but the two update calls passed it through untouched, so a request the server accepted and never answered had nothing to give up on. The AniList client already bounds its own writes this way, which is what makes the gap an oversight rather than a decision.

**Scope**
- Bound both list update calls by the same configured HTTP timeout the reads already use.
- Cover it with tests that park a server on the request and assert the call gives up on its own deadline.

**Impact** — A stalled write now fails after the configured timeout instead of hanging the run, and the sync reports it as an error rather than stopping. Successful updates are unaffected. Behaviour on a slow but responsive server is unchanged unless it exceeds the timeout that already governs every read.
