### PR TITLE
fix(hato): stop hammering a dead API and make the cache max age work

### DIFF
--- a/app.go
+++ b/app.go
@@ -261,7 +261,13 @@ func loadIDMappingStrategies(
 
 	var hatoClient *HatoClient
 	if config.HatoAPI.Enabled {
-		hatoClient = NewHatoClient(ctx, config.HatoAPI.BaseURL, config.GetHTTPTimeout(), config.HatoAPI.CacheDir)
+		hatoClient = NewHatoClient(
+			ctx,
+			config.HatoAPI.BaseURL,
+			config.GetHTTPTimeout(),
+			config.HatoAPI.CacheDir,
+			config.HatoAPI.CacheMaxAge,
+		)
 		LogInfoSuccess(ctx, "Hato API enabled (%s)", config.HatoAPI.BaseURL)
 	}
 

--- a/hato_api.go
+++ b/hato_api.go
@@ -5,10 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 )
 
-const defaultHatoBaseURL = "https://hato.malupdaterosx.moe"
+const (
+	defaultHatoBaseURL     = "https://hato.malupdaterosx.moe"
+	defaultHatoCacheMaxAge = 720 * time.Hour // 30 days
+	hatoMaxFailureStreak   = 5
+)
 
 // HatoClient is an HTTP client for the Hato API (https://hato.malupdaterosx.moe).
 // Supports both anime and manga ID mapping with persistent JSON caching.
@@ -16,6 +21,13 @@ type HatoClient struct {
 	baseURL    string
 	httpClient HTTPClient
 	cache      *HatoCache // Persistent cache (can be nil)
+
+	// Hato is a small third-party service that goes down for long stretches.
+	// Once it does, every lookup costs four retries with backoff, so the
+	// client stops asking for the rest of the run.
+	mu            sync.Mutex
+	failureStreak int
+	givenUp       bool
 }
 
 // HatoResponse represents the response from /api/mappings/{service}/{media_type}/{id}.
@@ -37,15 +49,27 @@ type HatoResponseData struct {
 
 // NewHatoClient creates a new Hato API client with optional caching.
 // If cacheDir is empty, caching is disabled (cache = nil).
-func NewHatoClient(ctx context.Context, baseURL string, timeout time.Duration, cacheDir string) *HatoClient {
+func NewHatoClient(
+	ctx context.Context,
+	baseURL string,
+	timeout time.Duration,
+	cacheDir string,
+	cacheMaxAgeStr string,
+) *HatoClient {
 	if baseURL == "" {
 		baseURL = defaultHatoBaseURL
+	}
+
+	maxAge := defaultHatoCacheMaxAge
+	parsed, err := time.ParseDuration(cacheMaxAgeStr)
+	if err == nil {
+		maxAge = parsed
 	}
 
 	var cache *HatoCache
 	if cacheDir != "" {
 		var err error
-		cache, err = NewHatoCache(cacheDir) //nolint:contextcheck // Cache init doesn't need context
+		cache, err = NewHatoCache(cacheDir, maxAge) //nolint:contextcheck // Cache init doesn't need context
 		if err != nil {
 			LogWarn(ctx, "Failed to initialize Hato cache: %v (caching disabled)", err)
 		} else {
@@ -78,6 +102,37 @@ func (c *HatoClient) setCachedData(service, mediaType string, id int, data HatoR
 	}
 }
 
+// gaveUp reports whether the client stopped talking to Hato for this run.
+func (c *HatoClient) gaveUp() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.givenUp
+}
+
+// noteFailure counts a failed request and stops the client once Hato looks down.
+func (c *HatoClient) noteFailure(ctx context.Context, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.failureStreak++
+	if c.givenUp || c.failureStreak < hatoMaxFailureStreak {
+		return
+	}
+
+	c.givenUp = true
+	LogWarn(ctx, "Hato API failed %d times in a row (%v), skipping it for the rest of this run",
+		c.failureStreak, err)
+}
+
+// noteSuccess clears the streak — the service answered, whatever the answer was.
+func (c *HatoClient) noteSuccess() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.failureStreak = 0
+}
+
 // GetAniListID returns the AniList ID for a given MAL ID and media type.
 // mediaType should be "anime" or "manga".
 // Checks cache first, then makes API request if needed.
@@ -92,6 +147,11 @@ func (c *HatoClient) GetAniListID(ctx context.Context, malID int, mediaType stri
 		}
 		// Cached negative result
 		LogDebug(ctx, "[HATO CACHE] HIT: MAL %d -> not found (cached) (%s)", malID, mediaType)
+		return 0, false, nil
+	}
+
+	// A negative result is never cached here: Hato being down is not an answer.
+	if c.gaveUp() {
 		return 0, false, nil
 	}
 
@@ -131,6 +191,11 @@ func (c *HatoClient) GetMALID(ctx context.Context, anilistID int, mediaType stri
 		}
 		// Cached negative result
 		LogDebug(ctx, "[HATO CACHE] HIT: AniList %d -> not found (cached) (%s)", anilistID, mediaType)
+		return 0, false, nil
+	}
+
+	// A negative result is never cached here: Hato being down is not an answer.
+	if c.gaveUp() {
 		return 0, false, nil
 	}
 
@@ -175,24 +240,32 @@ func (c *HatoClient) doRequest(ctx context.Context, url string) (*HatoResponse, 
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("request: %w", err)
+		err = fmt.Errorf("request: %w", err)
+		c.noteFailure(ctx, err)
+		return nil, err
 	}
 	defer resp.Body.Close() //nolint:errcheck // best effort close
 
 	LogDebug(ctx, "[HATO API] Status: %d", resp.StatusCode)
 
 	if resp.StatusCode == http.StatusNotFound {
+		c.noteSuccess()
 		return nil, nil //nolint:nilnil // nil means "not found", not an error
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+		err = fmt.Errorf("unexpected status: %s", resp.Status)
+		c.noteFailure(ctx, err)
+		return nil, err
 	}
 
 	var hatoResp HatoResponse
 	if err := json.NewDecoder(resp.Body).Decode(&hatoResp); err != nil {
-		return nil, fmt.Errorf("decode response: %w", err)
+		err = fmt.Errorf("decode response: %w", err)
+		c.noteFailure(ctx, err)
+		return nil, err
 	}
 
+	c.noteSuccess()
 	return &hatoResp, nil
 }

--- a/hato_api_test.go
+++ b/hato_api_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -530,4 +531,108 @@ func TestNewHatoClient_PassesCacheMaxAgeToTheCache(t *testing.T) {
 	// An unparsable value falls back to the documented default.
 	client = NewHatoClient(t.Context(), "", 5*time.Second, t.TempDir(), "nonsense")
 	assert.Equal(t, defaultHatoCacheMaxAge, client.cache.maxAge)
+}
+
+func TestHatoClient_GetMALID_ApiThenCache(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	malID := 13
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.URL.Path == "/api/mappings/anilist/anime/21" {
+			response := HatoResponse{}
+			response.Data.MalID = &malID
+			writeJSON(t, w, response)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cache, err := NewHatoCache(t.TempDir(), 720*time.Hour)
+	assert.NoError(t, err)
+
+	client := newUnretryingHatoClient(t, server.URL, cache)
+	ctx := NewLogger(false).WithContext(t.Context())
+
+	id, found, err := client.GetMALID(ctx, 21, mediaTypeAnime)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, malID, id)
+
+	id, found, err = client.GetMALID(ctx, 21, mediaTypeAnime)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, malID, id)
+	assert.Equal(t, 1, requests, "the second lookup must come from the cache")
+
+	// An unmapped title is cached as a negative and not asked for twice.
+	_, found, err = client.GetMALID(ctx, 999, mediaTypeAnime)
+	assert.NoError(t, err)
+	assert.False(t, found)
+
+	_, found, err = client.GetMALID(ctx, 999, mediaTypeAnime)
+	assert.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, 2, requests, "the negative result must be cached too")
+}
+
+func TestHatoClient_GetMALID_PropagatesFailures(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := newUnretryingHatoClient(t, server.URL, nil)
+	ctx := NewLogger(false).WithContext(t.Context())
+
+	id, found, err := client.GetMALID(ctx, 21, mediaTypeAnime)
+	assert.ErrorContains(t, err, "unexpected status")
+	assert.False(t, found)
+	assert.Zero(t, id)
+}
+
+func TestHatoClient_MalformedPayloadIsAFailure(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("{not json"))
+	}))
+	defer server.Close()
+
+	client := newUnretryingHatoClient(t, server.URL, nil)
+	ctx := NewLogger(false).WithContext(t.Context())
+
+	_, _, err := client.GetAniListID(ctx, 1, mediaTypeAnime)
+	assert.ErrorContains(t, err, "decode response")
+	assert.Equal(t, 1, client.failureStreak, "a broken payload counts as a failure")
+}
+
+func TestHatoClient_DoRequest_InvalidURL(t *testing.T) {
+	t.Parallel()
+	client := newUnretryingHatoClient(t, "http://exa mple.test", nil)
+
+	resp, err := client.doRequest(t.Context(), "http://exa mple.test/api/mappings/mal/anime/1")
+
+	assert.Nil(t, resp)
+	assert.ErrorContains(t, err, "create request")
+	assert.Zero(t, client.failureStreak, "a malformed URL is our bug, not an outage")
+}
+
+func TestHatoClient_SaveCache(t *testing.T) {
+	t.Parallel()
+	ctx := NewLogger(false).WithContext(t.Context())
+
+	assert.NoError(t, newUnretryingHatoClient(t, "http://example.test", nil).SaveCache(ctx))
+
+	tmpDir := t.TempDir()
+	cache, err := NewHatoCache(tmpDir, 720*time.Hour)
+	assert.NoError(t, err)
+
+	malID := 13
+	cache.Set("anilist", mediaTypeAnime, 21, HatoResponseData{MalID: &malID})
+
+	client := newUnretryingHatoClient(t, "http://example.test", cache)
+	assert.NoError(t, client.SaveCache(ctx))
+	assert.FileExists(t, filepath.Join(tmpDir, hatoCacheFile))
 }

--- a/hato_api_test.go
+++ b/hato_api_test.go
@@ -28,7 +28,7 @@ func TestHatoClient_GetAniListID_Anime(t *testing.T) {
 	defer server.Close()
 
 	// Test without cache
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 
 	id, found, err := client.GetAniListID(ctx, 1, mediaTypeAnime)
 	if err != nil {
@@ -57,7 +57,7 @@ func TestHatoClient_CacheHit(t *testing.T) {
 	defer server.Close()
 
 	// Create client with cache
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, tmpDir)
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, tmpDir, "720h")
 
 	// First request - cache MISS
 	id1, found1, err := client.GetAniListID(ctx, 1, mediaTypeAnime)
@@ -92,7 +92,7 @@ func TestHatoClient_GetAniListID_Manga(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 
 	id, found, err := client.GetAniListID(ctx, 92182, mediaTypeManga)
 	if err != nil {
@@ -119,7 +119,7 @@ func TestHatoClient_GetMALID_Anime(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 
 	id, found, err := client.GetMALID(ctx, 1, mediaTypeAnime)
 	if err != nil {
@@ -146,7 +146,7 @@ func TestHatoClient_GetMALID_Manga(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 
 	id, found, err := client.GetMALID(ctx, 87471, mediaTypeManga)
 	if err != nil {
@@ -165,7 +165,7 @@ func TestHatoClient_NotFound(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 
 	_, found, err := client.GetAniListID(ctx, 999999, mediaTypeAnime)
 	if err != nil {
@@ -182,7 +182,7 @@ func TestHatoClient_404(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 
 	_, found, err := client.GetAniListID(ctx, 999999, mediaTypeAnime)
 	if err != nil {
@@ -199,7 +199,7 @@ func TestHatoClient_ServerError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 
 	_, _, err := client.GetAniListID(ctx, 1, mediaTypeAnime)
 	assert.Error(t, err)
@@ -208,7 +208,7 @@ func TestHatoClient_ServerError(t *testing.T) {
 func TestHatoClient_Unreachable(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	client := NewHatoClient(ctx, "http://127.0.0.1:1", 1*time.Second, "")
+	client := NewHatoClient(ctx, "http://127.0.0.1:1", 1*time.Second, "", "720h")
 
 	_, _, err := client.GetAniListID(ctx, 1, mediaTypeAnime)
 	assert.Error(t, err)
@@ -227,7 +227,7 @@ func TestHatoClient_NegativeCache(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, tmpDir)
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, tmpDir, "720h")
 
 	// First request - not found
 	_, found1, err := client.GetAniListID(ctx, 999, mediaTypeAnime)
@@ -261,7 +261,7 @@ func TestHatoAPIStrategy_FindTarget_Anime(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 	strategy := HatoAPIStrategy{Client: client}
 	logCtx := NewLogger(false).WithContext(ctx)
 
@@ -308,7 +308,7 @@ func TestHatoAPIStrategy_FindTarget_Manga(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 	strategy := HatoAPIStrategy{Client: client}
 	logCtx := NewLogger(false).WithContext(ctx)
 
@@ -364,7 +364,7 @@ func TestHatoAPIStrategy_NotInUserList(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewHatoClient(ctx, server.URL, 5*time.Second, "")
+	client := NewHatoClient(ctx, server.URL, 5*time.Second, "", "720h")
 	strategy := HatoAPIStrategy{Client: client}
 	logCtx := NewLogger(false).WithContext(ctx)
 
@@ -380,14 +380,14 @@ func TestHatoAPIStrategy_NotInUserList(t *testing.T) {
 func TestNewHatoClient_DefaultURL(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	client := NewHatoClient(ctx, "", 5*time.Second, "")
+	client := NewHatoClient(ctx, "", 5*time.Second, "", "720h")
 	assert.Equal(t, defaultHatoBaseURL, client.baseURL)
 }
 
 func TestNewHatoClient_CustomURL(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
-	client := NewHatoClient(ctx, "http://localhost:3000", 5*time.Second, "")
+	client := NewHatoClient(ctx, "http://localhost:3000", 5*time.Second, "", "720h")
 	assert.Equal(t, "http://localhost:3000", client.baseURL)
 }
 
@@ -395,7 +395,139 @@ func TestNewHatoClient_WithCache(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	tmpDir := t.TempDir()
-	client := NewHatoClient(ctx, "", 5*time.Second, tmpDir)
+	client := NewHatoClient(ctx, "", 5*time.Second, tmpDir, "720h")
 	assert.NotNil(t, client.cache)
 	assert.Equal(t, 0, client.cache.Size())
+}
+
+// newUnretryingHatoClient points a client at a server without the retry
+// wrapper, so failure tests do not sit through the backoff.
+func newUnretryingHatoClient(t *testing.T, serverURL string, cache *HatoCache) *HatoClient {
+	t.Helper()
+	return &HatoClient{
+		baseURL:    serverURL,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+		cache:      cache,
+	}
+}
+
+func TestHatoClient_StopsCallingAfterRepeatedFailures(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := newUnretryingHatoClient(t, server.URL, nil)
+	ctx := NewLogger(false).WithContext(t.Context())
+
+	for i := range hatoMaxFailureStreak {
+		_, found, err := client.GetAniListID(ctx, 100+i, mediaTypeAnime)
+		assert.False(t, found)
+		assert.ErrorContains(t, err, "unexpected status")
+	}
+	assert.Equal(t, hatoMaxFailureStreak, requests)
+	assert.True(t, client.gaveUp())
+
+	// Further lookups are answered without touching the network.
+	id, found, err := client.GetMALID(ctx, 999, mediaTypeAnime)
+	assert.NoError(t, err)
+	assert.False(t, found)
+	assert.Zero(t, id)
+	assert.Equal(t, hatoMaxFailureStreak, requests, "no request may be sent once the client gave up")
+}
+
+func TestHatoClient_GivingUpDoesNotCacheNegativeResults(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cache, err := NewHatoCache(t.TempDir(), 720*time.Hour)
+	assert.NoError(t, err)
+
+	client := newUnretryingHatoClient(t, server.URL, cache)
+	ctx := NewLogger(false).WithContext(t.Context())
+
+	for i := range hatoMaxFailureStreak {
+		_, _, _ = client.GetAniListID(ctx, 100+i, mediaTypeAnime)
+	}
+	_, found, err := client.GetAniListID(ctx, 777, mediaTypeAnime)
+	assert.NoError(t, err)
+	assert.False(t, found)
+
+	// An outage is not an answer: nothing may be written, or the missing
+	// mapping would survive on disk long after Hato recovers.
+	assert.Equal(t, 0, cache.Size())
+}
+
+func TestHatoClient_RecoversWhenTheServiceAnswers(t *testing.T) {
+	t.Parallel()
+	failuresLeft := hatoMaxFailureStreak - 1
+	anilistID := 42
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if failuresLeft > 0 {
+			failuresLeft--
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		response := HatoResponse{}
+		response.Data.AniListID = &anilistID
+		writeJSON(t, w, response)
+	}))
+	defer server.Close()
+
+	client := newUnretryingHatoClient(t, server.URL, nil)
+	ctx := NewLogger(false).WithContext(t.Context())
+
+	for i := range hatoMaxFailureStreak - 1 {
+		_, _, err := client.GetAniListID(ctx, 100+i, mediaTypeAnime)
+		assert.Error(t, err)
+	}
+
+	id, found, err := client.GetAniListID(ctx, 200, mediaTypeAnime)
+	assert.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, anilistID, id)
+	assert.False(t, client.gaveUp())
+
+	// The streak must be cleared, not merely paused below the threshold.
+	failuresLeft = hatoMaxFailureStreak - 1
+	for i := range hatoMaxFailureStreak - 1 {
+		_, _, _ = client.GetAniListID(ctx, 300+i, mediaTypeAnime)
+	}
+	assert.False(t, client.gaveUp())
+}
+
+func TestHatoClient_A404IsAnAnswerNotAFailure(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := newUnretryingHatoClient(t, server.URL, nil)
+	ctx := NewLogger(false).WithContext(t.Context())
+
+	for i := range hatoMaxFailureStreak + 3 {
+		_, found, err := client.GetAniListID(ctx, 100+i, mediaTypeAnime)
+		assert.NoError(t, err)
+		assert.False(t, found)
+	}
+
+	assert.False(t, client.gaveUp(), "a missing mapping must not look like an outage")
+}
+
+func TestNewHatoClient_PassesCacheMaxAgeToTheCache(t *testing.T) {
+	t.Parallel()
+
+	client := NewHatoClient(t.Context(), "", 5*time.Second, t.TempDir(), "1h")
+	assert.Equal(t, time.Hour, client.cache.maxAge)
+
+	// An unparsable value falls back to the documented default.
+	client = NewHatoClient(t.Context(), "", 5*time.Second, t.TempDir(), "nonsense")
+	assert.Equal(t, defaultHatoCacheMaxAge, client.cache.maxAge)
 }

--- a/hato_cache.go
+++ b/hato_cache.go
@@ -26,13 +26,15 @@ type HatoCache struct {
 	entries  map[string]HatoCacheEntry
 	mu       sync.RWMutex
 	filePath string
+	maxAge   time.Duration
 	dirty    bool // Track if cache needs saving
 }
 
 // NewHatoCache creates a new cache instance and loads existing data.
+// A non-positive maxAge keeps entries forever.
 //
 //nolint:unparam // Error return kept for API compatibility
-func NewHatoCache(cacheDir string) (*HatoCache, error) {
+func NewHatoCache(cacheDir string, maxAge time.Duration) (*HatoCache, error) {
 	if cacheDir == "" {
 		cacheDir = getDefaultHatoCacheDir()
 	}
@@ -42,6 +44,7 @@ func NewHatoCache(cacheDir string) (*HatoCache, error) {
 	cache := &HatoCache{
 		entries:  make(map[string]HatoCacheEntry),
 		filePath: filePath,
+		maxAge:   maxAge,
 	}
 
 	// Load existing cache if it exists
@@ -57,7 +60,7 @@ func NewHatoCache(cacheDir string) (*HatoCache, error) {
 }
 
 // Get retrieves a cached mapping by key.
-// Returns (responseData, found).
+// Returns (responseData, found). Expired entries are treated as a cache miss.
 func (c *HatoCache) Get(service, mediaType string, id int) (*HatoResponseData, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -65,6 +68,12 @@ func (c *HatoCache) Get(service, mediaType string, id int) (*HatoResponseData, b
 	key := buildCacheKey(service, mediaType, id)
 	entry, exists := c.entries[key]
 	if !exists {
+		return nil, false
+	}
+
+	// Negative results are cached too, so without expiry a title that gained
+	// a mapping upstream would stay unmapped forever.
+	if c.maxAge > 0 && time.Since(entry.CachedAt) > c.maxAge {
 		return nil, false
 	}
 

--- a/hato_cache_test.go
+++ b/hato_cache_test.go
@@ -217,3 +217,38 @@ func TestHatoCache_ZeroMaxAgeKeepsEntriesForever(t *testing.T) {
 	assert.True(t, found)
 	assert.Equal(t, malID, *data.MalID)
 }
+
+func TestNewHatoCache_FallsBackToTheDefaultDir(t *testing.T) {
+	t.Parallel()
+	cache, err := NewHatoCache("", 720*time.Hour)
+
+	assert.NoError(t, err)
+	assert.Equal(t, getDefaultHatoCacheDir(), filepath.Dir(cache.filePath))
+	assert.Equal(t, hatoCacheFile, filepath.Base(cache.filePath))
+}
+
+func TestNewHatoCache_CorruptFileStartsFresh(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(tmpDir, hatoCacheFile), []byte("{not json"), 0o600))
+
+	cache, err := NewHatoCache(tmpDir, 720*time.Hour)
+
+	assert.NoError(t, err, "an unreadable cache must not break the run")
+	assert.Equal(t, 0, cache.Size())
+}
+
+func TestHatoCache_SaveReportsAnUnusableDirectory(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	blocker := filepath.Join(tmpDir, "blocker")
+	assert.NoError(t, os.WriteFile(blocker, []byte("not a directory"), 0o600))
+
+	cache, err := NewHatoCache(blocker, 720*time.Hour)
+	assert.NoError(t, err)
+
+	malID := 13
+	cache.Set("anilist", mediaTypeAnime, 21, HatoResponseData{MalID: &malID})
+
+	assert.ErrorContains(t, cache.Save(t.Context()), "create cache directory")
+}

--- a/hato_cache_test.go
+++ b/hato_cache_test.go
@@ -13,7 +13,7 @@ func TestNewHatoCache(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 
-	cache, err := NewHatoCache(tmpDir)
+	cache, err := NewHatoCache(tmpDir, 720*time.Hour)
 	assert.NoError(t, err)
 	assert.NotNil(t, cache)
 	assert.Equal(t, 0, cache.Size())
@@ -22,7 +22,7 @@ func TestNewHatoCache(t *testing.T) {
 func TestHatoCache_SetGet(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	cache, _ := NewHatoCache(tmpDir)
+	cache, _ := NewHatoCache(tmpDir, 720*time.Hour)
 
 	anilistID := 123
 	malID := 456
@@ -45,7 +45,7 @@ func TestHatoCache_SetGet(t *testing.T) {
 func TestHatoCache_NotFound(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	cache, _ := NewHatoCache(tmpDir)
+	cache, _ := NewHatoCache(tmpDir, 720*time.Hour)
 
 	_, found := cache.Get("mal", "anime", 999)
 	assert.False(t, found)
@@ -54,7 +54,7 @@ func TestHatoCache_NotFound(t *testing.T) {
 func TestHatoCache_SaveLoad(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	cache, _ := NewHatoCache(tmpDir)
+	cache, _ := NewHatoCache(tmpDir, 720*time.Hour)
 
 	anilistID := 123
 	malID := 456
@@ -72,7 +72,7 @@ func TestHatoCache_SaveLoad(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create new cache instance to load from disk
-	cache2, err := NewHatoCache(tmpDir)
+	cache2, err := NewHatoCache(tmpDir, 720*time.Hour)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, cache2.Size())
 
@@ -84,7 +84,7 @@ func TestHatoCache_SaveLoad(t *testing.T) {
 func TestHatoCache_DirtyFlag(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	cache, _ := NewHatoCache(tmpDir)
+	cache, _ := NewHatoCache(tmpDir, 720*time.Hour)
 
 	ctx := t.Context()
 
@@ -139,7 +139,7 @@ func TestHatoCache_BuildCacheKey(t *testing.T) {
 func TestHatoCache_MultipleEntries(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	cache, _ := NewHatoCache(tmpDir)
+	cache, _ := NewHatoCache(tmpDir, 720*time.Hour)
 
 	// Add multiple entries
 	for i := 1; i <= 10; i++ {
@@ -161,7 +161,7 @@ func TestHatoCache_MultipleEntries(t *testing.T) {
 func TestHatoCache_NegativeCache(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	cache, _ := NewHatoCache(tmpDir)
+	cache, _ := NewHatoCache(tmpDir, 720*time.Hour)
 
 	// Cache a negative result (empty data)
 	data := HatoResponseData{}
@@ -179,4 +179,41 @@ func TestGetDefaultHatoCacheDir(t *testing.T) {
 	assert.NotEmpty(t, dir)
 	assert.Contains(t, dir, "anilist-mal-sync")
 	assert.Contains(t, dir, "hato-cache")
+}
+
+func TestHatoCache_ExpiredEntryIsAMiss(t *testing.T) {
+	t.Parallel()
+	cache, err := NewHatoCache(t.TempDir(), time.Nanosecond)
+	assert.NoError(t, err)
+
+	anilistID := 5
+	cache.Set("mal", mediaTypeAnime, 1, HatoResponseData{AniListID: &anilistID})
+
+	_, found := cache.Get("mal", mediaTypeAnime, 1)
+	assert.False(t, found)
+}
+
+func TestHatoCache_ExpiryAppliesToNegativeEntries(t *testing.T) {
+	t.Parallel()
+	cache, err := NewHatoCache(t.TempDir(), time.Nanosecond)
+	assert.NoError(t, err)
+
+	// A title with no mapping yet must be retried once the entry ages out.
+	cache.Set("anilist", mediaTypeManga, 7, HatoResponseData{})
+
+	_, found := cache.Get("anilist", mediaTypeManga, 7)
+	assert.False(t, found)
+}
+
+func TestHatoCache_ZeroMaxAgeKeepsEntriesForever(t *testing.T) {
+	t.Parallel()
+	cache, err := NewHatoCache(t.TempDir(), 0)
+	assert.NoError(t, err)
+
+	malID := 13
+	cache.Set("anilist", mediaTypeAnime, 21, HatoResponseData{MalID: &malID})
+
+	data, found := cache.Get("anilist", mediaTypeAnime, 21)
+	assert.True(t, found)
+	assert.Equal(t, malID, *data.MalID)
 }

--- a/strategies.go
+++ b/strategies.go
@@ -559,7 +559,7 @@ func (s HatoAPIStrategy) FindTarget(
 	if srcAnime, ok := src.(Anime); ok {
 		targetServiceID, found, err := s.lookupIDAnime(ctx, srcAnime)
 		if err != nil {
-			LogDebug(ctx, "[%s] Hato API error: %v", prefix, err)
+			LogWarn(ctx, "[%s] Hato API error: %v", prefix, err)
 			return nil, false, nil
 		}
 		if found {
@@ -572,7 +572,7 @@ func (s HatoAPIStrategy) FindTarget(
 	if srcManga, ok := src.(Manga); ok {
 		targetServiceID, found, err := s.lookupIDManga(ctx, srcManga)
 		if err != nil {
-			LogDebug(ctx, "[%s] Hato API error: %v", prefix, err)
+			LogWarn(ctx, "[%s] Hato API error: %v", prefix, err)
 			return nil, false, nil
 		}
 		if found {


### PR DESCRIPTION
**Context** — Hato is a small third-party mapping service, enabled by default, and it is currently returning `500` on every mapping route (its own repository has not been touched since January 2024, and its last commit was a fix for exactly this kind of outage). The client had no way to notice. Each entry costs up to two lookups, each of which burns four attempts with exponential backoff, so a full list spent hours retrying a server that was never going to answer — and none of it was visible, because a failed lookup was logged at debug level and then returned as "no match". A throttled or dead service was indistinguishable from a title that genuinely has no mapping.

A second, unrelated defect surfaced while reading that code: `HATO_API_CACHE_MAX_AGE` is described in the config file, the README and the environment variable list, but the value never reached the cache. Entries therefore lived forever. Since a missing mapping is cached as a negative result too, a title that later gained a mapping upstream would have stayed unmapped permanently.

```
before:  entry → lookup(4 attempts, ~7s) → lookup(4 attempts, ~7s) → …repeat for every entry
after:   entry → lookup → …after a streak of failures the client stops asking for this run
```

**Scope**
- Stop calling Hato for the rest of the run once it fails several times in a row, and say so once at warning level.
- Treat an outage as "no answer", never as a result: nothing is written to the cache while the client has given up, so a bad day cannot leave permanent holes on disk.
- Keep a missing mapping (`404`) separate from a failure, and clear the streak whenever the service answers.
- Make the configured cache max age take effect, so both positive and negative entries expire.
- Report lookup failures at warning level instead of hiding them at debug level; the volume stays bounded because the client gives up early.
- Cover the reverse lookup, cache persistence and the failure paths, which previously had no tests beyond the happy path.

**Impact** — A Hato outage now costs a handful of requests and one warning line instead of hours of silent retrying, and it no longer degrades matching quality on subsequent runs through poisoned cache entries. Behaviour when the service is healthy is unchanged. Statement coverage for the touched files is 99% and 92%.

Note: the batch endpoint (10 ids per request) is deliberately out of scope here — it is down together with the rest of the API, and adopting it changes the resolve phase.
